### PR TITLE
Deploy to GH Pages on new commit

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,17 @@
+name: Deploy to GH Pages
+on: push
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+      - name: Build site
+        uses: Cecilapp/Cecil-Action@2.0.0
+      - name: Deploy site
+        uses: Cecilapp/GitHub-Pages-deploy@2.0.1
+        env:
+          EMAIL: dev@elao.com
+          GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          BUILD_DIR: _site

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,7 @@
 title: "Elao_"
 baseline: "Développe du lien_"
-baseurl: https://cecil.local/
+baseurl: https://elao.github.io/elao_/
+canonicalurl: true
 description: "Elao est un atelier de co-conception d'applications web et mobile sur mesure."
 author:
   name: Elao


### PR DESCRIPTION
Déploie automatiquement sur https://elao.github.io/elao_/ à chaque nouveau commit, permettant d'avoir un aperçu live d'une PR.

Ca utilise les gh-pages, donc un seul déploiement possible à la fois, çàd le dernier commit poussé sur le repo, et non une version par PR / branche, mais c'est déjà ça. 