### PR TITLE
Exclude samples on production env

### DIFF
--- a/.env
+++ b/.env
@@ -23,6 +23,7 @@ ROUTER_DEFAULT_URI=http://localhost
 
 ###> app ###
 GLIDE_PRE_GENERATE_CACHE=0
+INCLUDE_SAMPLES=1
 ###< app ###
 
 ###> symfony/mailer ###

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -85,6 +85,7 @@ jobs:
         env:
           APP_ENV: prod
           ROUTER_DEFAULT_URI: ${{ secrets.WEBSITE_URL }}
+          INCLUDE_SAMPLES: 0
 
       - name: '🚀 Deploy'
         run: |

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -23,6 +23,7 @@ services:
             - '../src/Tests/'
             - '../src/Bridge/Glide/Bundle/'
             - '../src/Stenope/Processor/ResizeImagesContentProcessor.php'
+            - '../src/Stenope/Provider/SampleRemovalProvider.php'
 
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class
@@ -52,3 +53,19 @@ services:
         arguments:
             $type: App\Model\Article
             $preset: article_content
+
+    App\Stenope\Provider\SampleRemovalProvider.Article:
+        class: App\Stenope\Provider\SampleRemovalProvider
+        decorates: stenope.provider.files.App\Model\Article
+        arguments:
+            $provider: '@.inner'
+            $disabled: '%env(bool:INCLUDE_SAMPLES)%'
+            $ignored: ['styleguide/example']
+
+    App\Stenope\Provider\SampleRemovalProvider.CaseStudy:
+        class: App\Stenope\Provider\SampleRemovalProvider
+        decorates: stenope.provider.files.App\Model\CaseStudy
+        arguments:
+            $provider: '@.inner'
+            $disabled: '%env(bool:INCLUDE_SAMPLES)%'
+            $ignored: ['example']

--- a/content/blog/styleguide/example.md
+++ b/content/blog/styleguide/example.md
@@ -5,7 +5,7 @@ title:              "Petit guide de style du blog"
 date:               "2020-09-23"
 publishdate:        "2020-09-23"
 draft:              true
-tableOfContent:  true
+tableOfContent:     true
 
 description:        "Tour d'horizon de ce qu'on a pour faire de beaux articles. Et quelques bonnes pratiques de rédaction."
 

--- a/src/Stenope/Provider/SampleRemovalProvider.php
+++ b/src/Stenope/Provider/SampleRemovalProvider.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Stenope\Provider;
+
+use Stenope\Bundle\Content;
+use Stenope\Bundle\Provider\ContentProviderInterface;
+use Stenope\Bundle\Provider\ReversibleContentProviderInterface;
+use Stenope\Bundle\ReverseContent\Context;
+
+/**
+ * Decorator for excluding some specific contents if enabled.
+ */
+class SampleRemovalProvider implements ReversibleContentProviderInterface
+{
+    private ContentProviderInterface $provider;
+    private bool $disabled;
+    /** @var string[] Ignored slugs */
+    private array $ignored;
+
+    public function __construct(ContentProviderInterface $provider, bool $disabled, array $ignored = [])
+    {
+        $this->provider = $provider;
+        $this->disabled = $disabled;
+        $this->ignored = $ignored;
+    }
+
+    public function listContents(): iterable
+    {
+        $contents = $this->provider->listContents();
+
+        if ($this->disabled) {
+            yield from $contents;
+
+            return;
+        }
+
+        foreach ($contents as $content) {
+            if (\in_array($content->getSlug(), $this->ignored, true)) {
+                continue;
+            }
+
+            yield $content;
+        }
+    }
+
+    public function getContent(string $slug): ?Content
+    {
+        if (!$this->disabled && \in_array($slug, $this->ignored, true)) {
+            return null;
+        }
+
+        return $this->provider->getContent($slug);
+    }
+
+    public function supports(string $className): bool
+    {
+        return $this->provider->supports($className);
+    }
+
+    public function reverse(Context $context): ?Content
+    {
+        if ($this->provider instanceof ReversibleContentProviderInterface) {
+            return $this->provider->reverse($context);
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Fixes #202

Exclusion au niveau des providers eux-mêmes, afin de ne pas avoir à se préoccuper de ça à chaque endroit où on consomme les contenus; avoir une exclusion globale et "transparente" via un simple flag.