### PR TITLE
Remove trailing slashes on some paths + exclude jobs for now

### DIFF
--- a/src/Controller/BlogController.php
+++ b/src/Controller/BlogController.php
@@ -24,7 +24,7 @@ class BlogController extends AbstractController
     }
 
     /**
-     * @Route("/", name="blog")
+     * @Route(name="blog")
      * @Route("/page/{!page}", name="blog_page", requirements={"page"="\d+"})
      */
     public function index(int $page = 1, int $perPage = 20): Response

--- a/src/Controller/CaseStudyController.php
+++ b/src/Controller/CaseStudyController.php
@@ -24,7 +24,7 @@ class CaseStudyController extends AbstractController
     }
 
     /**
-     * @Route("/", name="case_studies")
+     * @Route(name="case_studies")
      */
     public function list(): Response
     {

--- a/src/Controller/JobController.php
+++ b/src/Controller/JobController.php
@@ -12,7 +12,11 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route("/recrutement",)
+ * @Route("/recrutement", options={
+ *   "stenope": {
+ *     "ignore": true
+ *    }
+ * })
  */
 class JobController extends AbstractController
 {
@@ -24,7 +28,7 @@ class JobController extends AbstractController
     }
 
     /**
-     * @Route("/", name="jobs")
+     * @Route(name="jobs")
      */
     public function list(): Response
     {

--- a/src/Controller/TeamController.php
+++ b/src/Controller/TeamController.php
@@ -26,7 +26,7 @@ class TeamController extends AbstractController
     }
 
     /**
-     * @Route("/", name="team")
+     * @Route(name="team")
      */
     public function list(): Response
     {


### PR DESCRIPTION
On exclu les pages recrutements de la génération et du sitemap, étant donné qu'elles ne sont pas encore intégrées.