### PR TITLE
Add proper tag redirection

### DIFF
--- a/src/Command/GenerateRedirectionsCommand.php
+++ b/src/Command/GenerateRedirectionsCommand.php
@@ -6,8 +6,8 @@ namespace App\Command;
 
 use App\Legacy\HtaccessGenerator;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class GenerateRedirectionsCommand extends Command
@@ -27,14 +27,14 @@ class GenerateRedirectionsCommand extends Command
     {
         $this
             ->setDescription('Generate redirections rules for Nginx.')
-            ->addArgument('target', InputArgument::OPTIONAL, 'Target (site or blog)', HtaccessGenerator::TARGET_SITE)
+            ->addOption('target', 't', InputOption::VALUE_REQUIRED, HtaccessGenerator::TARGET_SITE)
         ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var string $target */
-        $target = $input->getArgument('target');
+        $target = $input->getOption('target');
         $output->writeln($this->generator->generateNginxRewriteRules($target));
 
         return Command::SUCCESS;


### PR DESCRIPTION
Voici la nouvelle liste de rules pour le blog : 

```
rewrite ^/$ http://localhost/blog permanent;
rewrite ^/fr$ http://localhost/blog permanent;
rewrite ^/fr/styleguide/example$ http://localhost/blog/styleguide/example permanent;
rewrite ^/fr/tags/tag-1$ http://localhost/blog/tag/tag-1 permanent;
rewrite ^/fr/tags/tag-2$ http://localhost/blog/tag/tag-2 permanent;
rewrite ^/fr/dev/webpack-encore-alias-namespace$ http://localhost/blog/dev/webpack-encore-alias-namespace permanent;
rewrite ^/fr/tags/symfony$ http://localhost/blog/tag/symfony permanent;
rewrite ^/fr/tags/javascript$ http://localhost/blog/tag/javascript permanent;
rewrite ^/fr/tags/webpack$ http://localhost/blog/tag/webpack permanent;
rewrite ^/fr/dev/apollo-graphql-cache$ http://localhost/blog/dev/apollo-graphql-cache permanent;
rewrite ^/fr/tags/graphql$ http://localhost/blog/tag/graphql permanent;
rewrite ^/fr/tags/cache$ http://localhost/blog/tag/cache permanent;
rewrite ^/fr/tags/apollo$ http://localhost/blog/tag/apollo permanent;
rewrite ^/fr/tags/api$ http://localhost/blog/tag/api permanent;
rewrite ^/fr/dev/offusquez-vos-id-dans-vos-url$ http://localhost/blog/dev/offusquez-vos-id-dans-vos-url permanent;
rewrite ^/fr/tags/securite$ http://localhost/blog/tag/securite permanent;
rewrite ^/fr/tags/php$ http://localhost/blog/tag/php permanent;
rewrite ^/fr/tags/framework$ http://localhost/blog/tag/framework permanent;
rewrite ^/fr/elao/halloween-2019$ http://localhost/blog/elao/halloween-2019 permanent;
rewrite ^/fr/tags/halloween$ http://localhost/blog/tag/halloween permanent;
rewrite ^/fr/tags/cinema$ http://localhost/blog/tag/cinema permanent;
rewrite ^/fr/dev/two-ways-binding-avec-vue-et-vuex$ http://localhost/blog/dev/two-ways-binding-avec-vue-et-vuex permanent;
rewrite ^/fr/tags/vuejs$ http://localhost/blog/tag/vuejs permanent;
rewrite ^/fr/tags/frontend$ http://localhost/blog/tag/frontend permanent;
rewrite ^/fr/dev/donnees-structurees-offre-emploi$ http://localhost/blog/dev/donnees-structurees-offre-emploi permanent;
rewrite ^/fr/tags/seo$ http://localhost/blog/tag/seo permanent;
rewrite ^/fr/tags/microdata$ http://localhost/blog/tag/microdata permanent;
rewrite ^/fr/tags/rich-snippets$ http://localhost/blog/tag/rich-snippets permanent;
rewrite ^/fr/dev/no-index-staging-symfony$ http://localhost/blog/dev/no-index-staging-symfony permanent;
rewrite ^/fr/tags/no-index$ http://localhost/blog/tag/no-index permanent;
rewrite ^/fr/elao/afup-day-lyon-2019$ http://localhost/blog/elao/afup-day-lyon-2019 permanent;
rewrite ^/fr/tags/developpement$ http://localhost/blog/tag/developpement permanent;
rewrite ^/fr/tags/web$ http://localhost/blog/tag/web permanent;
rewrite ^/fr/tags/afup$ http://localhost/blog/tag/afup permanent;
rewrite ^/fr/tags/conference$ http://localhost/blog/tag/conference permanent;
rewrite ^/fr/tags/afupday$ http://localhost/blog/tag/afupday permanent;
rewrite ^/fr/dev/retour-experience-matomo$ http://localhost/blog/dev/retour-experience-matomo permanent;
rewrite ^/fr/tags/rgpd$ http://localhost/blog/tag/rgpd permanent;
rewrite ^/fr/tags/matomo$ http://localhost/blog/tag/matomo permanent;
rewrite ^/fr/dev/manalize-virtualiser-son-environnement-de-developpement$ http://localhost/blog/dev/manalize-virtualiser-son-environnement-de-developpement permanent;
rewrite ^/fr/tags/manala$ http://localhost/blog/tag/manala permanent;
rewrite ^/fr/tags/virtualisation$ http://localhost/blog/tag/virtualisation permanent;
rewrite ^/fr/tags/ansible$ http://localhost/blog/tag/ansible permanent;
rewrite ^/fr/tags/vagrant$ http://localhost/blog/tag/vagrant permanent;
rewrite ^/fr/elao/forum-php-2018$ http://localhost/blog/elao/forum-php-2018 permanent;
rewrite ^/fr/tags/forumphp$ http://localhost/blog/tag/forumphp permanent;
rewrite ^/fr/dev/comment-demarrer-tdd-en-php$ http://localhost/blog/dev/comment-demarrer-tdd-en-php permanent;
rewrite ^/fr/tags/test$ http://localhost/blog/tag/test permanent;
rewrite ^/fr/tags/tdd$ http://localhost/blog/tag/tdd permanent;
rewrite ^/fr/dev/commander-au-clavier-app-symfony-grace-au-routing$ http://localhost/blog/dev/commander-au-clavier-app-symfony-grace-au-routing permanent;
rewrite ^/fr/tags/routing$ http://localhost/blog/tag/routing permanent;
rewrite ^/fr/tags/ux$ http://localhost/blog/tag/ux permanent;
rewrite ^/fr/dev/ecrire-des-tests-behat-proches-de-son-domaine$ http://localhost/blog/dev/ecrire-des-tests-behat-proches-de-son-domaine permanent;
rewrite ^/fr/tags/behat$ http://localhost/blog/tag/behat permanent;
rewrite ^/fr/tags/ddd$ http://localhost/blog/tag/ddd permanent;
rewrite ^/fr/elao/elao-paris$ http://localhost/blog/elao/elao-paris permanent;
rewrite ^/fr/tags/paris$ http://localhost/blog/tag/paris permanent;
rewrite ^/fr/tags/recrutement$ http://localhost/blog/tag/recrutement permanent;
rewrite ^/fr/tags/tribu$ http://localhost/blog/tag/tribu permanent;
rewrite ^/fr/elao/mixit-2018$ http://localhost/blog/elao/mixit-2018 permanent;
rewrite ^/fr/dev/authentification-par-lien-magique$ http://localhost/blog/dev/authentification-par-lien-magique permanent;
rewrite ^/fr/tags/authentification$ http://localhost/blog/tag/authentification permanent;
rewrite ^/fr/tags/email$ http://localhost/blog/tag/email permanent;
rewrite ^/fr/tags/magiclink$ http://localhost/blog/tag/magiclink permanent;
rewrite ^/fr/dev/react-native-font-icon$ http://localhost/blog/dev/react-native-font-icon permanent;
rewrite ^/fr/tags/react-native$ http://localhost/blog/tag/react-native permanent;
rewrite ^/fr/tags/mobile$ http://localhost/blog/tag/mobile permanent;
rewrite ^/fr/tags/font$ http://localhost/blog/tag/font permanent;
rewrite ^/fr/tags/icon$ http://localhost/blog/tag/icon permanent;
rewrite ^/fr/dev/api-design-elao-team-interview$ http://localhost/blog/dev/api-design-elao-team-interview permanent;
rewrite ^/fr/tags/conception$ http://localhost/blog/tag/conception permanent;
rewrite ^/fr/tags/rest$ http://localhost/blog/tag/rest permanent;
rewrite ^/fr/tags/api-design$ http://localhost/blog/tag/api-design permanent;
rewrite ^/fr/dev/progressive-web-app-chalkboard-education-elearning-sans-internet$ http://localhost/blog/dev/progressive-web-app-chalkboard-education-elearning-sans-internet permanent;
rewrite ^/fr/tags/progressive-web-app$ http://localhost/blog/tag/progressive-web-app permanent;
rewrite ^/fr/tags/offline$ http://localhost/blog/tag/offline permanent;
rewrite ^/fr/tags/react$ http://localhost/blog/tag/react permanent;
rewrite ^/fr/dev/date-php-timezone-utc-pourquoi-est-ce-important$ http://localhost/blog/dev/date-php-timezone-utc-pourquoi-est-ce-important permanent;
rewrite ^/fr/tags/datetime$ http://localhost/blog/tag/datetime permanent;
rewrite ^/fr/tags/timezone$ http://localhost/blog/tag/timezone permanent;
rewrite ^/en/dev/from-react-native-init-to-app-stores-real-quick$ http://localhost/blog/dev/from-react-native-init-to-app-stores-real-quick permanent;
rewrite ^/fr/elao/blendwebmix-2017$ http://localhost/blog/elao/blendwebmix-2017 permanent;
rewrite ^/fr/tags/blend$ http://localhost/blog/tag/blend permanent;
rewrite ^/fr/tags/lyon$ http://localhost/blog/tag/lyon permanent;
rewrite ^/fr/tags/design$ http://localhost/blog/tag/design permanent;
rewrite ^/fr/tags/business$ http://localhost/blog/tag/business permanent;
rewrite ^/fr/dev/planification-de-rdv-avec-optaplanner$ http://localhost/blog/dev/planification-de-rdv-avec-optaplanner permanent;
rewrite ^/fr/tags/planification$ http://localhost/blog/tag/planification permanent;
rewrite ^/fr/tags/optaplanner$ http://localhost/blog/tag/optaplanner permanent;
rewrite ^/fr/dev/migrer-mots-de-passe-utilisateur-autre-methode-encodage-symfony$ http://localhost/blog/dev/migrer-mots-de-passe-utilisateur-autre-methode-encodage-symfony permanent;
rewrite ^/fr/tags/migration$ http://localhost/blog/tag/migration permanent;
rewrite ^/fr/tags/encodage$ http://localhost/blog/tag/encodage permanent;
rewrite ^/fr/elao/nuit-du-hack-XV$ http://localhost/blog/elao/nuit-du-hack-XV permanent;
rewrite ^/fr/tags/sysadmin$ http://localhost/blog/tag/sysadmin permanent;
rewrite ^/fr/tags/hacking$ http://localhost/blog/tag/hacking permanent;
rewrite ^/fr/methodo/github-agile-dashboard$ http://localhost/blog/methodo/github-agile-dashboard permanent;
rewrite ^/fr/tags/agile$ http://localhost/blog/tag/agile permanent;
rewrite ^/fr/tags/scrum$ http://localhost/blog/tag/scrum permanent;
rewrite ^/fr/tags/kanban$ http://localhost/blog/tag/kanban permanent;
rewrite ^/fr/tags/gestion-de-projet$ http://localhost/blog/tag/gestion-de-projet permanent;
rewrite ^/fr/tags/github$ http://localhost/blog/tag/github permanent;
rewrite ^/fr/tags/git$ http://localhost/blog/tag/git permanent;
rewrite ^/fr/tags/node$ http://localhost/blog/tag/node permanent;
rewrite ^/fr/tags/cli$ http://localhost/blog/tag/cli permanent;
rewrite ^/fr/dev/architecture-hexagonale-symfony$ http://localhost/blog/dev/architecture-hexagonale-symfony permanent;
rewrite ^/fr/tags/architecture$ http://localhost/blog/tag/architecture permanent;
rewrite ^/fr/dev/design-pattern-chain-of-responsibility$ http://localhost/blog/dev/design-pattern-chain-of-responsibility permanent;
rewrite ^/fr/tags/design-pattern$ http://localhost/blog/tag/design-pattern permanent;
rewrite ^/fr/elao/dotscale-paris-2017$ http://localhost/blog/elao/dotscale-paris-2017 permanent;
rewrite ^/fr/tags/devops$ http://localhost/blog/tag/devops permanent;
rewrite ^/fr/tags/infrastructure$ http://localhost/blog/tag/infrastructure permanent;
rewrite ^/fr/tags/scalabilite$ http://localhost/blog/tag/scalabilite permanent;
rewrite ^/fr/dev/ameliorez-pertinence-resultat-elastic-search-score$ http://localhost/blog/dev/ameliorez-pertinence-resultat-elastic-search-score permanent;
rewrite ^/fr/tags/moteur-de-recherche$ http://localhost/blog/tag/moteur-de-recherche permanent;
rewrite ^/fr/tags/elasticsearch$ http://localhost/blog/tag/elasticsearch permanent;
rewrite ^/fr/tags/pertinence$ http://localhost/blog/tag/pertinence permanent;
rewrite ^/fr/tags/elastica$ http://localhost/blog/tag/elastica permanent;
rewrite ^/fr/infra/introduction-a-vagrant$ http://localhost/blog/infra/introduction-a-vagrant permanent;
rewrite ^/fr/methodo/gestion-projet-agile-github$ http://localhost/blog/methodo/gestion-projet-agile-github permanent;
rewrite ^/fr/dev/design-pattern-decorator$ http://localhost/blog/dev/design-pattern-decorator permanent;
rewrite ^/fr/dev/design-pattern-abstract-factory$ http://localhost/blog/dev/design-pattern-abstract-factory permanent;
rewrite ^/fr/dev/design-pattern-factory-method$ http://localhost/blog/dev/design-pattern-factory-method permanent;
rewrite ^/fr/infra/provisonner-simplement-stack-monitoring-telegraf-influxdb-grafana-avec-manala$ http://localhost/blog/infra/provisonner-simplement-stack-monitoring-telegraf-influxdb-grafana-avec-manala permanent;
rewrite ^/fr/tags/provisoning$ http://localhost/blog/tag/provisoning permanent;
rewrite ^/fr/tags/influxdb$ http://localhost/blog/tag/influxdb permanent;
rewrite ^/fr/tags/grafana$ http://localhost/blog/tag/grafana permanent;
rewrite ^/fr/tags/telegraf$ http://localhost/blog/tag/telegraf permanent;
rewrite ^/fr/tags/monitoring$ http://localhost/blog/tag/monitoring permanent;
rewrite ^/fr/infra/utiliser-l-api-openstack-ovh$ http://localhost/blog/infra/utiliser-l-api-openstack-ovh permanent;
rewrite ^/fr/tags/ovh$ http://localhost/blog/tag/ovh permanent;
rewrite ^/fr/tags/openstack$ http://localhost/blog/tag/openstack permanent;
rewrite ^/fr/tags/docker$ http://localhost/blog/tag/docker permanent;
rewrite ^/fr/tags/infra$ http://localhost/blog/tag/infra permanent;
rewrite ^/fr/dev/la-revanche-du-web-par-les-progressive-web-apps$ http://localhost/blog/dev/la-revanche-du-web-par-les-progressive-web-apps permanent;
rewrite ^/fr/tags/service-worker$ http://localhost/blog/tag/service-worker permanent;
rewrite ^/fr/methodo/notre-quotidien-equipe-projet-auto-organisee$ http://localhost/blog/methodo/notre-quotidien-equipe-projet-auto-organisee permanent;
rewrite ^/fr/tags/user-stories$ http://localhost/blog/tag/user-stories permanent;
rewrite ^/fr/elao/blendwebmix-2016$ http://localhost/blog/elao/blendwebmix-2016 permanent;
rewrite ^/fr/elao/forum-php-2016$ http://localhost/blog/elao/forum-php-2016 permanent;
rewrite ^/fr/dev/realisez-une-application-vue-js-avec-vue-cli$ http://localhost/blog/dev/realisez-une-application-vue-js-avec-vue-cli permanent;
rewrite ^/fr/tags/front$ http://localhost/blog/tag/front permanent;
rewrite ^/fr/infra/acceder-api-cross-domain-depuis-javascript-avec-cors-reverse-proxy-nginx$ http://localhost/blog/infra/acceder-api-cross-domain-depuis-javascript-avec-cors-reverse-proxy-nginx permanent;
rewrite ^/fr/tags/nginx$ http://localhost/blog/tag/nginx permanent;
rewrite ^/fr/tags/reverse$ http://localhost/blog/tag/reverse permanent;
rewrite ^/fr/tags/proxy$ http://localhost/blog/tag/proxy permanent;
rewrite ^/fr/tags/cors$ http://localhost/blog/tag/cors permanent;
rewrite ^/fr/dev/comment-integrer-vue-js-application-symfony$ http://localhost/blog/dev/comment-integrer-vue-js-application-symfony permanent;
rewrite ^/fr/dev/pourquoi-devriez-vous-utiliser-vue-js-dans-vos-projets$ http://localhost/blog/dev/pourquoi-devriez-vous-utiliser-vue-js-dans-vos-projets permanent;
rewrite ^/en/tech/ssh-agent-does-not-automatically-load-passphrases-on-the-osx-sierra-keychain$ http://localhost/blog/tech/ssh-agent-does-not-automatically-load-passphrases-on-the-osx-sierra-keychain permanent;
rewrite ^/fr/tags/ssh$ http://localhost/blog/tag/ssh permanent;
rewrite ^/fr/tags/osx$ http://localhost/blog/tag/osx permanent;
rewrite ^/fr/elao/best-of-web-2016$ http://localhost/blog/elao/best-of-web-2016 permanent;
rewrite ^/fr/elao/phptour-2016$ http://localhost/blog/elao/phptour-2016 permanent;
rewrite ^/fr/tags/clermont-ech$ http://localhost/blog/tag/clermont-ech permanent;
rewrite ^/fr/elao/ncrafts-2016$ http://localhost/blog/elao/ncrafts-2016 permanent;
rewrite ^/fr/tags/ncrafts$ http://localhost/blog/tag/ncrafts permanent;
rewrite ^/fr/tags/craftsmanship$ http://localhost/blog/tag/craftsmanship permanent;
rewrite ^/fr/infra/introduction-au-provisioning$ http://localhost/blog/infra/introduction-au-provisioning permanent;
rewrite ^/fr/tags/linux$ http://localhost/blog/tag/linux permanent;
rewrite ^/fr/elao/symfonycon-2015$ http://localhost/blog/elao/symfonycon-2015 permanent;
rewrite ^/fr/tags/symfonycon$ http://localhost/blog/tag/symfonycon permanent;
rewrite ^/fr/infra/comprendre-lheritage-des-instructions-de-configuration-de-nginx$ http://localhost/blog/infra/comprendre-lheritage-des-instructions-de-configuration-de-nginx permanent;
rewrite ^/fr/methodo/specifions-user-stories$ http://localhost/blog/methodo/specifions-user-stories permanent;
rewrite ^/fr/tags/specifications$ http://localhost/blog/tag/specifications permanent;
rewrite ^/fr/elao/forum-php-2015$ http://localhost/blog/elao/forum-php-2015 permanent;
rewrite ^/fr/dev/behat-3-test-fonctionnel-symfony$ http://localhost/blog/dev/behat-3-test-fonctionnel-symfony permanent;
rewrite ^/fr/tags/mink$ http://localhost/blog/tag/mink permanent;
rewrite ^/fr/tags/alice$ http://localhost/blog/tag/alice permanent;
rewrite ^/fr/elao/retour-paris-web$ http://localhost/blog/elao/retour-paris-web permanent;
rewrite ^/fr/tags/parisweb$ http://localhost/blog/tag/parisweb permanent;
rewrite ^/fr/tags/conferences$ http://localhost/blog/tag/conferences permanent;
rewrite ^/fr/elao/le-teletravail-point-de-vue$ http://localhost/blog/elao/le-teletravail-point-de-vue permanent;
rewrite ^/fr/tags/teletravail$ http://localhost/blog/tag/teletravail permanent;
rewrite ^/fr/tags/vie-au-travail$ http://localhost/blog/tag/vie-au-travail permanent;
rewrite ^/fr/dev/meteor-multi-apps-architecture$ http://localhost/blog/dev/meteor-multi-apps-architecture permanent;
rewrite ^/fr/tags/meteor$ http://localhost/blog/tag/meteor permanent;
rewrite ^/fr/tags/tips$ http://localhost/blog/tag/tips permanent;
rewrite ^/fr/tags/bonnes-pratiques$ http://localhost/blog/tag/bonnes-pratiques permanent;
rewrite ^/fr/elao/best-of-web-2015$ http://localhost/blog/elao/best-of-web-2015 permanent;
rewrite ^/fr/elao/nodeschool-paris$ http://localhost/blog/elao/nodeschool-paris permanent;
rewrite ^/fr/tags/node-js$ http://localhost/blog/tag/node-js permanent;
rewrite ^/fr/elao/mix-it-2015-pt1$ http://localhost/blog/elao/mix-it-2015-pt1 permanent;
rewrite ^/fr/tags/mix-it-2015$ http://localhost/blog/tag/mix-it-2015 permanent;
rewrite ^/fr/elao/symfony-live-2015$ http://localhost/blog/elao/symfony-live-2015 permanent;
rewrite ^/fr/tags/symfony-live$ http://localhost/blog/tag/symfony-live permanent;
rewrite ^/fr/infra/ssl-generer-une-demande-de-signature-de-certificat-csr$ http://localhost/blog/infra/ssl-generer-une-demande-de-signature-de-certificat-csr permanent;
rewrite ^/fr/tags/ssl$ http://localhost/blog/tag/ssl permanent;
rewrite ^/fr/tags/certicats$ http://localhost/blog/tag/certicats permanent;
rewrite ^/fr/infra/authentification-http-avec-haproxy$ http://localhost/blog/infra/authentification-http-avec-haproxy permanent;
rewrite ^/fr/tags/ha-proxy$ http://localhost/blog/tag/ha-proxy permanent;
rewrite ^/fr/tags/network$ http://localhost/blog/tag/network permanent;
rewrite ^/fr/infra/creer-un-cluster-2-nodes-proxmox$ http://localhost/blog/infra/creer-un-cluster-2-nodes-proxmox permanent;
rewrite ^/fr/tags/proxmox$ http://localhost/blog/tag/proxmox permanent;
rewrite ^/fr/tags/openvz$ http://localhost/blog/tag/openvz permanent;
rewrite ^/fr/tags/cluster$ http://localhost/blog/tag/cluster permanent;
rewrite ^/fr/infra/utiliser-supervisor-pour-controler-ses-services-applicatifs$ http://localhost/blog/infra/utiliser-supervisor-pour-controler-ses-services-applicatifs permanent;
rewrite ^/fr/tags/services$ http://localhost/blog/tag/services permanent;
rewrite ^/fr/tags/debian$ http://localhost/blog/tag/debian permanent;
rewrite ^/fr/tags/supervisor$ http://localhost/blog/tag/supervisor permanent;
rewrite ^/fr/infra/installer-graphite-sur-debian-wheezy$ http://localhost/blog/infra/installer-graphite-sur-debian-wheezy permanent;
rewrite ^/fr/infra/utiliser-les-depots-officiels-nginx-sur-debian-wheezy$ http://localhost/blog/infra/utiliser-les-depots-officiels-nginx-sur-debian-wheezy permanent;
rewrite ^/fr/infra/partitionnement-d-un-serveur-proxmox$ http://localhost/blog/infra/partitionnement-d-un-serveur-proxmox permanent;
rewrite ^/fr/tags/partitionnement$ http://localhost/blog/tag/partitionnement permanent;
rewrite ^/fr/tech/creer-une-cle-bootable-osx-10-10-yosemite$ http://localhost/blog/tech/creer-une-cle-bootable-osx-10-10-yosemite permanent;
rewrite ^/fr/elao/hs-bien-preparer-sa-conference$ http://localhost/blog/elao/hs-bien-preparer-sa-conference permanent;
rewrite ^/fr/tags/talk$ http://localhost/blog/tag/talk permanent;
rewrite ^/fr/tags/aisance$ http://localhost/blog/tag/aisance permanent;
rewrite ^/fr/tags/oral$ http://localhost/blog/tag/oral permanent;
rewrite ^/fr/tags/preparation$ http://localhost/blog/tag/preparation permanent;
rewrite ^/fr/dev/plusieurs-mailer-dans-une-application-symfony-2$ http://localhost/blog/dev/plusieurs-mailer-dans-une-application-symfony-2 permanent;
rewrite ^/fr/tags/errornotifierbundle$ http://localhost/blog/tag/errornotifierbundle permanent;
rewrite ^/fr/tags/swiftmailer$ http://localhost/blog/tag/swiftmailer permanent;
rewrite ^/fr/tags/mailer-transport$ http://localhost/blog/tag/mailer-transport permanent;
rewrite ^/en/dev/a-nice-way-of-handing-form-label-translation$ http://localhost/blog/dev/a-nice-way-of-handing-form-label-translation permanent;
rewrite ^/fr/tags/form$ http://localhost/blog/tag/form permanent;
rewrite ^/fr/tags/theming$ http://localhost/blog/tag/theming permanent;
rewrite ^/fr/tags/translation$ http://localhost/blog/tag/translation permanent;
rewrite ^/fr/dev/the-browserdetectorbundle-working-with-the-kernel-events$ http://localhost/blog/dev/the-browserdetectorbundle-working-with-the-kernel-events permanent;
rewrite ^/fr/tags/kernel$ http://localhost/blog/tag/kernel permanent;
rewrite ^/fr/tags/browser$ http://localhost/blog/tag/browser permanent;
rewrite ^/en/infra/feedback-monitor-your-symfony2-application-via-stats-d-and-graphite$ http://localhost/blog/infra/feedback-monitor-your-symfony2-application-via-stats-d-and-graphite permanent;
rewrite ^/fr/tags/carbon$ http://localhost/blog/tag/carbon permanent;
rewrite ^/fr/tags/graphite$ http://localhost/blog/tag/graphite permanent;
rewrite ^/fr/tags/stats-d$ http://localhost/blog/tag/stats-d permanent;
rewrite ^/fr/tags/webperf$ http://localhost/blog/tag/webperf permanent;
rewrite ^/fr/dev/utilisation-de-levenement-kernel-terminate-sous-symfony2$ http://localhost/blog/dev/utilisation-de-levenement-kernel-terminate-sous-symfony2 permanent;
rewrite ^/fr/tags/bundle$ http://localhost/blog/tag/bundle permanent;
rewrite ^/fr/tags/doctrine$ http://localhost/blog/tag/doctrine permanent;
rewrite ^/fr/tags/translations$ http://localhost/blog/tag/translations permanent;
rewrite ^/fr/dev/twig-quelques-pro-tips-issue-du-symfony-live-2013$ http://localhost/blog/dev/twig-quelques-pro-tips-issue-du-symfony-live-2013 permanent;
rewrite ^/fr/tags/twig$ http://localhost/blog/tag/twig permanent;
rewrite ^/fr/tags/symfony-2$ http://localhost/blog/tag/symfony-2 permanent;
rewrite ^/fr/dev/bonnes-pratiques-symfony2-notre-condense$ http://localhost/blog/dev/bonnes-pratiques-symfony2-notre-condense permanent;
rewrite ^/fr/dev/maintenabilite-et-performance-avec-sass-et-compass$ http://localhost/blog/dev/maintenabilite-et-performance-avec-sass-et-compass permanent;
rewrite ^/fr/tags/css$ http://localhost/blog/tag/css permanent;
rewrite ^/fr/tags/webdesign$ http://localhost/blog/tag/webdesign permanent;
rewrite ^/en/dev/subdomains-symfony2-2-session-authentication$ http://localhost/blog/dev/subdomains-symfony2-2-session-authentication permanent;
rewrite ^/en/infra/install-stats-d-graphite-on-a-debian-server-to-monitor-a-symfony2-application$ http://localhost/blog/infra/install-stats-d-graphite-on-a-debian-server-to-monitor-a-symfony2-application permanent;
rewrite ^/en/infra/monitor-your-symfony2-application-via-stats-d-and-graphite-2$ http://localhost/blog/infra/monitor-your-symfony2-application-via-stats-d-and-graphite-2 permanent;
rewrite ^/fr/tags/statd$ http://localhost/blog/tag/statd permanent;
rewrite ^/fr/tags/ops$ http://localhost/blog/tag/ops permanent;
rewrite ^/fr/dev/responsive-web-design$ http://localhost/blog/dev/responsive-web-design permanent;
rewrite ^/en/dev/how-to-manage-translations-for-your-object-using-sonataadminbundle$ http://localhost/blog/dev/how-to-manage-translations-for-your-object-using-sonataadminbundle permanent;
rewrite ^/fr/infra/migrer-un-site-web-sans-interruption-de-service-grace-au-reverse-proxy-dapache$ http://localhost/blog/infra/migrer-un-site-web-sans-interruption-de-service-grace-au-reverse-proxy-dapache permanent;
rewrite ^/fr/tags/apache$ http://localhost/blog/tag/apache permanent;
rewrite ^/fr/tags/trucs-et-astuces$ http://localhost/blog/tag/trucs-et-astuces permanent;
rewrite ^/en/dev/symfony-2-doctrine-2-cheat-sheets$ http://localhost/blog/dev/symfony-2-doctrine-2-cheat-sheets permanent;
rewrite ^/fr/tags/cheat-sheets$ http://localhost/blog/tag/cheat-sheets permanent;
rewrite ^/fr/dev/django-3eme-partie-les-templates-et-bien-dautres-choses$ http://localhost/blog/dev/django-3eme-partie-les-templates-et-bien-dautres-choses permanent;
rewrite ^/fr/tags/django$ http://localhost/blog/tag/django permanent;
rewrite ^/fr/tags/mvc$ http://localhost/blog/tag/mvc permanent;
rewrite ^/fr/tags/python$ http://localhost/blog/tag/python permanent;
rewrite ^/fr/dev/django-2nde-partie-le-modele-et-ladmin$ http://localhost/blog/dev/django-2nde-partie-le-modele-et-ladmin permanent;
rewrite ^/fr/infra/creer-une-autorite-de-certification-et-des-certificats-ssl-auto-signes$ http://localhost/blog/infra/creer-une-autorite-de-certification-et-des-certificats-ssl-auto-signes permanent;
rewrite ^/fr/dev/premiers-pas-avec-le-framework-python-django$ http://localhost/blog/dev/premiers-pas-avec-le-framework-python-django permanent;
rewrite ^/fr/dev/installation-et-premiers-pas-avec-le-plugin-symfony-sfimagetransformextraplugin$ http://localhost/blog/dev/installation-et-premiers-pas-avec-le-plugin-symfony-sfimagetransformextraplugin permanent;
rewrite ^/fr/dev/symfony-2-linjection-de-dependances$ http://localhost/blog/dev/symfony-2-linjection-de-dependances permanent;
rewrite ^/fr/tech/configuration-de-bind-sous-mac-os-x$ http://localhost/blog/tech/configuration-de-bind-sous-mac-os-x permanent;
rewrite ^/fr/tags/bind$ http://localhost/blog/tag/bind permanent;
rewrite ^/fr/tags/mac-osx$ http://localhost/blog/tag/mac-osx permanent;
rewrite ^/fr/dev/propel-utiliser-des-champs-calcules$ http://localhost/blog/dev/propel-utiliser-des-champs-calcules permanent;
rewrite ^/fr/tags/propel$ http://localhost/blog/tag/propel permanent;
rewrite ^/fr/tags/orm$ http://localhost/blog/tag/orm permanent;
rewrite ^/fr/infra/utilisation-de-la-commande-find-cas-pratiques$ http://localhost/blog/infra/utilisation-de-la-commande-find-cas-pratiques permanent;
rewrite ^/fr/infra/authentifications-multiples-a-partir-de-cles-ssh$ http://localhost/blog/infra/authentifications-multiples-a-partir-de-cles-ssh permanent;
rewrite ^/fr/infra/securiser-ses-acces-serveur-authentification-par-cles-ssh$ http://localhost/blog/infra/securiser-ses-acces-serveur-authentification-par-cles-ssh permanent;
rewrite ^/fr/infra/installation-de-fuse-et-s3fs-sur-une-debian-lenny$ http://localhost/blog/infra/installation-de-fuse-et-s3fs-sur-une-debian-lenny permanent;
rewrite ^/fr/tags/fuse$ http://localhost/blog/tag/fuse permanent;
rewrite ^/fr/tags/s3fs$ http://localhost/blog/tag/s3fs permanent;
rewrite ^/fr/infra/syntaxe-des-enregistrements-spf-sender-privacy-framework$ http://localhost/blog/infra/syntaxe-des-enregistrements-spf-sender-privacy-framework permanent;
rewrite ^/fr/tags/spf$ http://localhost/blog/tag/spf permanent;
rewrite ^/fr/infra/operation-sur-un-fichier-avec-la-commande-find$ http://localhost/blog/infra/operation-sur-un-fichier-avec-la-commande-find permanent;
rewrite ^/fr/infra/installation-d-un-depot-svn$ http://localhost/blog/infra/installation-d-un-depot-svn permanent;
rewrite ^/fr/tags/svn$ http://localhost/blog/tag/svn permanent;
rewrite ^/fr/$ http://localhost/blog permanent;
rewrite ^/fr/styleguide/example/$ http://localhost/blog/styleguide/example permanent;
rewrite ^/fr/tags/tag-1/$ http://localhost/blog/tag/tag-1 permanent;
rewrite ^/fr/tags/tag-2/$ http://localhost/blog/tag/tag-2 permanent;
rewrite ^/fr/dev/webpack-encore-alias-namespace/$ http://localhost/blog/dev/webpack-encore-alias-namespace permanent;
rewrite ^/fr/tags/symfony/$ http://localhost/blog/tag/symfony permanent;
rewrite ^/fr/tags/javascript/$ http://localhost/blog/tag/javascript permanent;
rewrite ^/fr/tags/webpack/$ http://localhost/blog/tag/webpack permanent;
rewrite ^/fr/dev/apollo-graphql-cache/$ http://localhost/blog/dev/apollo-graphql-cache permanent;
rewrite ^/fr/tags/graphql/$ http://localhost/blog/tag/graphql permanent;
rewrite ^/fr/tags/cache/$ http://localhost/blog/tag/cache permanent;
rewrite ^/fr/tags/apollo/$ http://localhost/blog/tag/apollo permanent;
rewrite ^/fr/tags/api/$ http://localhost/blog/tag/api permanent;
rewrite ^/fr/dev/offusquez-vos-id-dans-vos-url/$ http://localhost/blog/dev/offusquez-vos-id-dans-vos-url permanent;
rewrite ^/fr/tags/securite/$ http://localhost/blog/tag/securite permanent;
rewrite ^/fr/tags/php/$ http://localhost/blog/tag/php permanent;
rewrite ^/fr/tags/framework/$ http://localhost/blog/tag/framework permanent;
rewrite ^/fr/elao/halloween-2019/$ http://localhost/blog/elao/halloween-2019 permanent;
rewrite ^/fr/tags/halloween/$ http://localhost/blog/tag/halloween permanent;
rewrite ^/fr/tags/cinema/$ http://localhost/blog/tag/cinema permanent;
rewrite ^/fr/dev/two-ways-binding-avec-vue-et-vuex/$ http://localhost/blog/dev/two-ways-binding-avec-vue-et-vuex permanent;
rewrite ^/fr/tags/vuejs/$ http://localhost/blog/tag/vuejs permanent;
rewrite ^/fr/tags/frontend/$ http://localhost/blog/tag/frontend permanent;
rewrite ^/fr/dev/donnees-structurees-offre-emploi/$ http://localhost/blog/dev/donnees-structurees-offre-emploi permanent;
rewrite ^/fr/tags/seo/$ http://localhost/blog/tag/seo permanent;
rewrite ^/fr/tags/microdata/$ http://localhost/blog/tag/microdata permanent;
rewrite ^/fr/tags/rich-snippets/$ http://localhost/blog/tag/rich-snippets permanent;
rewrite ^/fr/dev/no-index-staging-symfony/$ http://localhost/blog/dev/no-index-staging-symfony permanent;
rewrite ^/fr/tags/no-index/$ http://localhost/blog/tag/no-index permanent;
rewrite ^/fr/elao/afup-day-lyon-2019/$ http://localhost/blog/elao/afup-day-lyon-2019 permanent;
rewrite ^/fr/tags/developpement/$ http://localhost/blog/tag/developpement permanent;
rewrite ^/fr/tags/web/$ http://localhost/blog/tag/web permanent;
rewrite ^/fr/tags/afup/$ http://localhost/blog/tag/afup permanent;
rewrite ^/fr/tags/conference/$ http://localhost/blog/tag/conference permanent;
rewrite ^/fr/tags/afupday/$ http://localhost/blog/tag/afupday permanent;
rewrite ^/fr/dev/retour-experience-matomo/$ http://localhost/blog/dev/retour-experience-matomo permanent;
rewrite ^/fr/tags/rgpd/$ http://localhost/blog/tag/rgpd permanent;
rewrite ^/fr/tags/matomo/$ http://localhost/blog/tag/matomo permanent;
rewrite ^/fr/dev/manalize-virtualiser-son-environnement-de-developpement/$ http://localhost/blog/dev/manalize-virtualiser-son-environnement-de-developpement permanent;
rewrite ^/fr/tags/manala/$ http://localhost/blog/tag/manala permanent;
rewrite ^/fr/tags/virtualisation/$ http://localhost/blog/tag/virtualisation permanent;
rewrite ^/fr/tags/ansible/$ http://localhost/blog/tag/ansible permanent;
rewrite ^/fr/tags/vagrant/$ http://localhost/blog/tag/vagrant permanent;
rewrite ^/fr/elao/forum-php-2018/$ http://localhost/blog/elao/forum-php-2018 permanent;
rewrite ^/fr/tags/forumphp/$ http://localhost/blog/tag/forumphp permanent;
rewrite ^/fr/dev/comment-demarrer-tdd-en-php/$ http://localhost/blog/dev/comment-demarrer-tdd-en-php permanent;
rewrite ^/fr/tags/test/$ http://localhost/blog/tag/test permanent;
rewrite ^/fr/tags/tdd/$ http://localhost/blog/tag/tdd permanent;
rewrite ^/fr/dev/commander-au-clavier-app-symfony-grace-au-routing/$ http://localhost/blog/dev/commander-au-clavier-app-symfony-grace-au-routing permanent;
rewrite ^/fr/tags/routing/$ http://localhost/blog/tag/routing permanent;
rewrite ^/fr/tags/ux/$ http://localhost/blog/tag/ux permanent;
rewrite ^/fr/dev/ecrire-des-tests-behat-proches-de-son-domaine/$ http://localhost/blog/dev/ecrire-des-tests-behat-proches-de-son-domaine permanent;
rewrite ^/fr/tags/behat/$ http://localhost/blog/tag/behat permanent;
rewrite ^/fr/tags/ddd/$ http://localhost/blog/tag/ddd permanent;
rewrite ^/fr/elao/elao-paris/$ http://localhost/blog/elao/elao-paris permanent;
rewrite ^/fr/tags/paris/$ http://localhost/blog/tag/paris permanent;
rewrite ^/fr/tags/recrutement/$ http://localhost/blog/tag/recrutement permanent;
rewrite ^/fr/tags/tribu/$ http://localhost/blog/tag/tribu permanent;
rewrite ^/fr/elao/mixit-2018/$ http://localhost/blog/elao/mixit-2018 permanent;
rewrite ^/fr/dev/authentification-par-lien-magique/$ http://localhost/blog/dev/authentification-par-lien-magique permanent;
rewrite ^/fr/tags/authentification/$ http://localhost/blog/tag/authentification permanent;
rewrite ^/fr/tags/email/$ http://localhost/blog/tag/email permanent;
rewrite ^/fr/tags/magiclink/$ http://localhost/blog/tag/magiclink permanent;
rewrite ^/fr/dev/react-native-font-icon/$ http://localhost/blog/dev/react-native-font-icon permanent;
rewrite ^/fr/tags/react-native/$ http://localhost/blog/tag/react-native permanent;
rewrite ^/fr/tags/mobile/$ http://localhost/blog/tag/mobile permanent;
rewrite ^/fr/tags/font/$ http://localhost/blog/tag/font permanent;
rewrite ^/fr/tags/icon/$ http://localhost/blog/tag/icon permanent;
rewrite ^/fr/dev/api-design-elao-team-interview/$ http://localhost/blog/dev/api-design-elao-team-interview permanent;
rewrite ^/fr/tags/conception/$ http://localhost/blog/tag/conception permanent;
rewrite ^/fr/tags/rest/$ http://localhost/blog/tag/rest permanent;
rewrite ^/fr/tags/api-design/$ http://localhost/blog/tag/api-design permanent;
rewrite ^/fr/dev/progressive-web-app-chalkboard-education-elearning-sans-internet/$ http://localhost/blog/dev/progressive-web-app-chalkboard-education-elearning-sans-internet permanent;
rewrite ^/fr/tags/progressive-web-app/$ http://localhost/blog/tag/progressive-web-app permanent;
rewrite ^/fr/tags/offline/$ http://localhost/blog/tag/offline permanent;
rewrite ^/fr/tags/react/$ http://localhost/blog/tag/react permanent;
rewrite ^/fr/dev/date-php-timezone-utc-pourquoi-est-ce-important/$ http://localhost/blog/dev/date-php-timezone-utc-pourquoi-est-ce-important permanent;
rewrite ^/fr/tags/datetime/$ http://localhost/blog/tag/datetime permanent;
rewrite ^/fr/tags/timezone/$ http://localhost/blog/tag/timezone permanent;
rewrite ^/en/dev/from-react-native-init-to-app-stores-real-quick/$ http://localhost/blog/dev/from-react-native-init-to-app-stores-real-quick permanent;
rewrite ^/fr/elao/blendwebmix-2017/$ http://localhost/blog/elao/blendwebmix-2017 permanent;
rewrite ^/fr/tags/blend/$ http://localhost/blog/tag/blend permanent;
rewrite ^/fr/tags/lyon/$ http://localhost/blog/tag/lyon permanent;
rewrite ^/fr/tags/design/$ http://localhost/blog/tag/design permanent;
rewrite ^/fr/tags/business/$ http://localhost/blog/tag/business permanent;
rewrite ^/fr/dev/planification-de-rdv-avec-optaplanner/$ http://localhost/blog/dev/planification-de-rdv-avec-optaplanner permanent;
rewrite ^/fr/tags/planification/$ http://localhost/blog/tag/planification permanent;
rewrite ^/fr/tags/optaplanner/$ http://localhost/blog/tag/optaplanner permanent;
rewrite ^/fr/dev/migrer-mots-de-passe-utilisateur-autre-methode-encodage-symfony/$ http://localhost/blog/dev/migrer-mots-de-passe-utilisateur-autre-methode-encodage-symfony permanent;
rewrite ^/fr/tags/migration/$ http://localhost/blog/tag/migration permanent;
rewrite ^/fr/tags/encodage/$ http://localhost/blog/tag/encodage permanent;
rewrite ^/fr/elao/nuit-du-hack-XV/$ http://localhost/blog/elao/nuit-du-hack-XV permanent;
rewrite ^/fr/tags/sysadmin/$ http://localhost/blog/tag/sysadmin permanent;
rewrite ^/fr/tags/hacking/$ http://localhost/blog/tag/hacking permanent;
rewrite ^/fr/methodo/github-agile-dashboard/$ http://localhost/blog/methodo/github-agile-dashboard permanent;
rewrite ^/fr/tags/agile/$ http://localhost/blog/tag/agile permanent;
rewrite ^/fr/tags/scrum/$ http://localhost/blog/tag/scrum permanent;
rewrite ^/fr/tags/kanban/$ http://localhost/blog/tag/kanban permanent;
rewrite ^/fr/tags/gestion-de-projet/$ http://localhost/blog/tag/gestion-de-projet permanent;
rewrite ^/fr/tags/github/$ http://localhost/blog/tag/github permanent;
rewrite ^/fr/tags/git/$ http://localhost/blog/tag/git permanent;
rewrite ^/fr/tags/node/$ http://localhost/blog/tag/node permanent;
rewrite ^/fr/tags/cli/$ http://localhost/blog/tag/cli permanent;
rewrite ^/fr/dev/architecture-hexagonale-symfony/$ http://localhost/blog/dev/architecture-hexagonale-symfony permanent;
rewrite ^/fr/tags/architecture/$ http://localhost/blog/tag/architecture permanent;
rewrite ^/fr/dev/design-pattern-chain-of-responsibility/$ http://localhost/blog/dev/design-pattern-chain-of-responsibility permanent;
rewrite ^/fr/tags/design-pattern/$ http://localhost/blog/tag/design-pattern permanent;
rewrite ^/fr/elao/dotscale-paris-2017/$ http://localhost/blog/elao/dotscale-paris-2017 permanent;
rewrite ^/fr/tags/devops/$ http://localhost/blog/tag/devops permanent;
rewrite ^/fr/tags/infrastructure/$ http://localhost/blog/tag/infrastructure permanent;
rewrite ^/fr/tags/scalabilite/$ http://localhost/blog/tag/scalabilite permanent;
rewrite ^/fr/dev/ameliorez-pertinence-resultat-elastic-search-score/$ http://localhost/blog/dev/ameliorez-pertinence-resultat-elastic-search-score permanent;
rewrite ^/fr/tags/moteur-de-recherche/$ http://localhost/blog/tag/moteur-de-recherche permanent;
rewrite ^/fr/tags/elasticsearch/$ http://localhost/blog/tag/elasticsearch permanent;
rewrite ^/fr/tags/pertinence/$ http://localhost/blog/tag/pertinence permanent;
rewrite ^/fr/tags/elastica/$ http://localhost/blog/tag/elastica permanent;
rewrite ^/fr/infra/introduction-a-vagrant/$ http://localhost/blog/infra/introduction-a-vagrant permanent;
rewrite ^/fr/methodo/gestion-projet-agile-github/$ http://localhost/blog/methodo/gestion-projet-agile-github permanent;
rewrite ^/fr/dev/design-pattern-decorator/$ http://localhost/blog/dev/design-pattern-decorator permanent;
rewrite ^/fr/dev/design-pattern-abstract-factory/$ http://localhost/blog/dev/design-pattern-abstract-factory permanent;
rewrite ^/fr/dev/design-pattern-factory-method/$ http://localhost/blog/dev/design-pattern-factory-method permanent;
rewrite ^/fr/infra/provisonner-simplement-stack-monitoring-telegraf-influxdb-grafana-avec-manala/$ http://localhost/blog/infra/provisonner-simplement-stack-monitoring-telegraf-influxdb-grafana-avec-manala permanent;
rewrite ^/fr/tags/provisoning/$ http://localhost/blog/tag/provisoning permanent;
rewrite ^/fr/tags/influxdb/$ http://localhost/blog/tag/influxdb permanent;
rewrite ^/fr/tags/grafana/$ http://localhost/blog/tag/grafana permanent;
rewrite ^/fr/tags/telegraf/$ http://localhost/blog/tag/telegraf permanent;
rewrite ^/fr/tags/monitoring/$ http://localhost/blog/tag/monitoring permanent;
rewrite ^/fr/infra/utiliser-l-api-openstack-ovh/$ http://localhost/blog/infra/utiliser-l-api-openstack-ovh permanent;
rewrite ^/fr/tags/ovh/$ http://localhost/blog/tag/ovh permanent;
rewrite ^/fr/tags/openstack/$ http://localhost/blog/tag/openstack permanent;
rewrite ^/fr/tags/docker/$ http://localhost/blog/tag/docker permanent;
rewrite ^/fr/tags/infra/$ http://localhost/blog/tag/infra permanent;
rewrite ^/fr/dev/la-revanche-du-web-par-les-progressive-web-apps/$ http://localhost/blog/dev/la-revanche-du-web-par-les-progressive-web-apps permanent;
rewrite ^/fr/tags/service-worker/$ http://localhost/blog/tag/service-worker permanent;
rewrite ^/fr/methodo/notre-quotidien-equipe-projet-auto-organisee/$ http://localhost/blog/methodo/notre-quotidien-equipe-projet-auto-organisee permanent;
rewrite ^/fr/tags/user-stories/$ http://localhost/blog/tag/user-stories permanent;
rewrite ^/fr/elao/blendwebmix-2016/$ http://localhost/blog/elao/blendwebmix-2016 permanent;
rewrite ^/fr/elao/forum-php-2016/$ http://localhost/blog/elao/forum-php-2016 permanent;
rewrite ^/fr/dev/realisez-une-application-vue-js-avec-vue-cli/$ http://localhost/blog/dev/realisez-une-application-vue-js-avec-vue-cli permanent;
rewrite ^/fr/tags/front/$ http://localhost/blog/tag/front permanent;
rewrite ^/fr/infra/acceder-api-cross-domain-depuis-javascript-avec-cors-reverse-proxy-nginx/$ http://localhost/blog/infra/acceder-api-cross-domain-depuis-javascript-avec-cors-reverse-proxy-nginx permanent;
rewrite ^/fr/tags/nginx/$ http://localhost/blog/tag/nginx permanent;
rewrite ^/fr/tags/reverse/$ http://localhost/blog/tag/reverse permanent;
rewrite ^/fr/tags/proxy/$ http://localhost/blog/tag/proxy permanent;
rewrite ^/fr/tags/cors/$ http://localhost/blog/tag/cors permanent;
rewrite ^/fr/dev/comment-integrer-vue-js-application-symfony/$ http://localhost/blog/dev/comment-integrer-vue-js-application-symfony permanent;
rewrite ^/fr/dev/pourquoi-devriez-vous-utiliser-vue-js-dans-vos-projets/$ http://localhost/blog/dev/pourquoi-devriez-vous-utiliser-vue-js-dans-vos-projets permanent;
rewrite ^/en/tech/ssh-agent-does-not-automatically-load-passphrases-on-the-osx-sierra-keychain/$ http://localhost/blog/tech/ssh-agent-does-not-automatically-load-passphrases-on-the-osx-sierra-keychain permanent;
rewrite ^/fr/tags/ssh/$ http://localhost/blog/tag/ssh permanent;
rewrite ^/fr/tags/osx/$ http://localhost/blog/tag/osx permanent;
rewrite ^/fr/elao/best-of-web-2016/$ http://localhost/blog/elao/best-of-web-2016 permanent;
rewrite ^/fr/elao/phptour-2016/$ http://localhost/blog/elao/phptour-2016 permanent;
rewrite ^/fr/tags/clermont-ech/$ http://localhost/blog/tag/clermont-ech permanent;
rewrite ^/fr/elao/ncrafts-2016/$ http://localhost/blog/elao/ncrafts-2016 permanent;
rewrite ^/fr/tags/ncrafts/$ http://localhost/blog/tag/ncrafts permanent;
rewrite ^/fr/tags/craftsmanship/$ http://localhost/blog/tag/craftsmanship permanent;
rewrite ^/fr/infra/introduction-au-provisioning/$ http://localhost/blog/infra/introduction-au-provisioning permanent;
rewrite ^/fr/tags/linux/$ http://localhost/blog/tag/linux permanent;
rewrite ^/fr/elao/symfonycon-2015/$ http://localhost/blog/elao/symfonycon-2015 permanent;
rewrite ^/fr/tags/symfonycon/$ http://localhost/blog/tag/symfonycon permanent;
rewrite ^/fr/infra/comprendre-lheritage-des-instructions-de-configuration-de-nginx/$ http://localhost/blog/infra/comprendre-lheritage-des-instructions-de-configuration-de-nginx permanent;
rewrite ^/fr/methodo/specifions-user-stories/$ http://localhost/blog/methodo/specifions-user-stories permanent;
rewrite ^/fr/tags/specifications/$ http://localhost/blog/tag/specifications permanent;
rewrite ^/fr/elao/forum-php-2015/$ http://localhost/blog/elao/forum-php-2015 permanent;
rewrite ^/fr/dev/behat-3-test-fonctionnel-symfony/$ http://localhost/blog/dev/behat-3-test-fonctionnel-symfony permanent;
rewrite ^/fr/tags/mink/$ http://localhost/blog/tag/mink permanent;
rewrite ^/fr/tags/alice/$ http://localhost/blog/tag/alice permanent;
rewrite ^/fr/elao/retour-paris-web/$ http://localhost/blog/elao/retour-paris-web permanent;
rewrite ^/fr/tags/parisweb/$ http://localhost/blog/tag/parisweb permanent;
rewrite ^/fr/tags/conferences/$ http://localhost/blog/tag/conferences permanent;
rewrite ^/fr/elao/le-teletravail-point-de-vue/$ http://localhost/blog/elao/le-teletravail-point-de-vue permanent;
rewrite ^/fr/tags/teletravail/$ http://localhost/blog/tag/teletravail permanent;
rewrite ^/fr/tags/vie-au-travail/$ http://localhost/blog/tag/vie-au-travail permanent;
rewrite ^/fr/dev/meteor-multi-apps-architecture/$ http://localhost/blog/dev/meteor-multi-apps-architecture permanent;
rewrite ^/fr/tags/meteor/$ http://localhost/blog/tag/meteor permanent;
rewrite ^/fr/tags/tips/$ http://localhost/blog/tag/tips permanent;
rewrite ^/fr/tags/bonnes-pratiques/$ http://localhost/blog/tag/bonnes-pratiques permanent;
rewrite ^/fr/elao/best-of-web-2015/$ http://localhost/blog/elao/best-of-web-2015 permanent;
rewrite ^/fr/elao/nodeschool-paris/$ http://localhost/blog/elao/nodeschool-paris permanent;
rewrite ^/fr/tags/node-js/$ http://localhost/blog/tag/node-js permanent;
rewrite ^/fr/elao/mix-it-2015-pt1/$ http://localhost/blog/elao/mix-it-2015-pt1 permanent;
rewrite ^/fr/tags/mix-it-2015/$ http://localhost/blog/tag/mix-it-2015 permanent;
rewrite ^/fr/elao/symfony-live-2015/$ http://localhost/blog/elao/symfony-live-2015 permanent;
rewrite ^/fr/tags/symfony-live/$ http://localhost/blog/tag/symfony-live permanent;
rewrite ^/fr/infra/ssl-generer-une-demande-de-signature-de-certificat-csr/$ http://localhost/blog/infra/ssl-generer-une-demande-de-signature-de-certificat-csr permanent;
rewrite ^/fr/tags/ssl/$ http://localhost/blog/tag/ssl permanent;
rewrite ^/fr/tags/certicats/$ http://localhost/blog/tag/certicats permanent;
rewrite ^/fr/infra/authentification-http-avec-haproxy/$ http://localhost/blog/infra/authentification-http-avec-haproxy permanent;
rewrite ^/fr/tags/ha-proxy/$ http://localhost/blog/tag/ha-proxy permanent;
rewrite ^/fr/tags/network/$ http://localhost/blog/tag/network permanent;
rewrite ^/fr/infra/creer-un-cluster-2-nodes-proxmox/$ http://localhost/blog/infra/creer-un-cluster-2-nodes-proxmox permanent;
rewrite ^/fr/tags/proxmox/$ http://localhost/blog/tag/proxmox permanent;
rewrite ^/fr/tags/openvz/$ http://localhost/blog/tag/openvz permanent;
rewrite ^/fr/tags/cluster/$ http://localhost/blog/tag/cluster permanent;
rewrite ^/fr/infra/utiliser-supervisor-pour-controler-ses-services-applicatifs/$ http://localhost/blog/infra/utiliser-supervisor-pour-controler-ses-services-applicatifs permanent;
rewrite ^/fr/tags/services/$ http://localhost/blog/tag/services permanent;
rewrite ^/fr/tags/debian/$ http://localhost/blog/tag/debian permanent;
rewrite ^/fr/tags/supervisor/$ http://localhost/blog/tag/supervisor permanent;
rewrite ^/fr/infra/installer-graphite-sur-debian-wheezy/$ http://localhost/blog/infra/installer-graphite-sur-debian-wheezy permanent;
rewrite ^/fr/infra/utiliser-les-depots-officiels-nginx-sur-debian-wheezy/$ http://localhost/blog/infra/utiliser-les-depots-officiels-nginx-sur-debian-wheezy permanent;
rewrite ^/fr/infra/partitionnement-d-un-serveur-proxmox/$ http://localhost/blog/infra/partitionnement-d-un-serveur-proxmox permanent;
rewrite ^/fr/tags/partitionnement/$ http://localhost/blog/tag/partitionnement permanent;
rewrite ^/fr/tech/creer-une-cle-bootable-osx-10-10-yosemite/$ http://localhost/blog/tech/creer-une-cle-bootable-osx-10-10-yosemite permanent;
rewrite ^/fr/elao/hs-bien-preparer-sa-conference/$ http://localhost/blog/elao/hs-bien-preparer-sa-conference permanent;
rewrite ^/fr/tags/talk/$ http://localhost/blog/tag/talk permanent;
rewrite ^/fr/tags/aisance/$ http://localhost/blog/tag/aisance permanent;
rewrite ^/fr/tags/oral/$ http://localhost/blog/tag/oral permanent;
rewrite ^/fr/tags/preparation/$ http://localhost/blog/tag/preparation permanent;
rewrite ^/fr/dev/plusieurs-mailer-dans-une-application-symfony-2/$ http://localhost/blog/dev/plusieurs-mailer-dans-une-application-symfony-2 permanent;
rewrite ^/fr/tags/errornotifierbundle/$ http://localhost/blog/tag/errornotifierbundle permanent;
rewrite ^/fr/tags/swiftmailer/$ http://localhost/blog/tag/swiftmailer permanent;
rewrite ^/fr/tags/mailer-transport/$ http://localhost/blog/tag/mailer-transport permanent;
rewrite ^/en/dev/a-nice-way-of-handing-form-label-translation/$ http://localhost/blog/dev/a-nice-way-of-handing-form-label-translation permanent;
rewrite ^/fr/tags/form/$ http://localhost/blog/tag/form permanent;
rewrite ^/fr/tags/theming/$ http://localhost/blog/tag/theming permanent;
rewrite ^/fr/tags/translation/$ http://localhost/blog/tag/translation permanent;
rewrite ^/fr/dev/the-browserdetectorbundle-working-with-the-kernel-events/$ http://localhost/blog/dev/the-browserdetectorbundle-working-with-the-kernel-events permanent;
rewrite ^/fr/tags/kernel/$ http://localhost/blog/tag/kernel permanent;
rewrite ^/fr/tags/browser/$ http://localhost/blog/tag/browser permanent;
rewrite ^/en/infra/feedback-monitor-your-symfony2-application-via-stats-d-and-graphite/$ http://localhost/blog/infra/feedback-monitor-your-symfony2-application-via-stats-d-and-graphite permanent;
rewrite ^/fr/tags/carbon/$ http://localhost/blog/tag/carbon permanent;
rewrite ^/fr/tags/graphite/$ http://localhost/blog/tag/graphite permanent;
rewrite ^/fr/tags/stats-d/$ http://localhost/blog/tag/stats-d permanent;
rewrite ^/fr/tags/webperf/$ http://localhost/blog/tag/webperf permanent;
rewrite ^/fr/dev/utilisation-de-levenement-kernel-terminate-sous-symfony2/$ http://localhost/blog/dev/utilisation-de-levenement-kernel-terminate-sous-symfony2 permanent;
rewrite ^/fr/tags/bundle/$ http://localhost/blog/tag/bundle permanent;
rewrite ^/fr/tags/doctrine/$ http://localhost/blog/tag/doctrine permanent;
rewrite ^/fr/tags/translations/$ http://localhost/blog/tag/translations permanent;
rewrite ^/fr/dev/twig-quelques-pro-tips-issue-du-symfony-live-2013/$ http://localhost/blog/dev/twig-quelques-pro-tips-issue-du-symfony-live-2013 permanent;
rewrite ^/fr/tags/twig/$ http://localhost/blog/tag/twig permanent;
rewrite ^/fr/tags/symfony-2/$ http://localhost/blog/tag/symfony-2 permanent;
rewrite ^/fr/dev/bonnes-pratiques-symfony2-notre-condense/$ http://localhost/blog/dev/bonnes-pratiques-symfony2-notre-condense permanent;
rewrite ^/fr/dev/maintenabilite-et-performance-avec-sass-et-compass/$ http://localhost/blog/dev/maintenabilite-et-performance-avec-sass-et-compass permanent;
rewrite ^/fr/tags/css/$ http://localhost/blog/tag/css permanent;
rewrite ^/fr/tags/webdesign/$ http://localhost/blog/tag/webdesign permanent;
rewrite ^/en/dev/subdomains-symfony2-2-session-authentication/$ http://localhost/blog/dev/subdomains-symfony2-2-session-authentication permanent;
rewrite ^/en/infra/install-stats-d-graphite-on-a-debian-server-to-monitor-a-symfony2-application/$ http://localhost/blog/infra/install-stats-d-graphite-on-a-debian-server-to-monitor-a-symfony2-application permanent;
rewrite ^/en/infra/monitor-your-symfony2-application-via-stats-d-and-graphite-2/$ http://localhost/blog/infra/monitor-your-symfony2-application-via-stats-d-and-graphite-2 permanent;
rewrite ^/fr/tags/statd/$ http://localhost/blog/tag/statd permanent;
rewrite ^/fr/tags/ops/$ http://localhost/blog/tag/ops permanent;
rewrite ^/fr/dev/responsive-web-design/$ http://localhost/blog/dev/responsive-web-design permanent;
rewrite ^/en/dev/how-to-manage-translations-for-your-object-using-sonataadminbundle/$ http://localhost/blog/dev/how-to-manage-translations-for-your-object-using-sonataadminbundle permanent;
rewrite ^/fr/infra/migrer-un-site-web-sans-interruption-de-service-grace-au-reverse-proxy-dapache/$ http://localhost/blog/infra/migrer-un-site-web-sans-interruption-de-service-grace-au-reverse-proxy-dapache permanent;
rewrite ^/fr/tags/apache/$ http://localhost/blog/tag/apache permanent;
rewrite ^/fr/tags/trucs-et-astuces/$ http://localhost/blog/tag/trucs-et-astuces permanent;
rewrite ^/en/dev/symfony-2-doctrine-2-cheat-sheets/$ http://localhost/blog/dev/symfony-2-doctrine-2-cheat-sheets permanent;
rewrite ^/fr/tags/cheat-sheets/$ http://localhost/blog/tag/cheat-sheets permanent;
rewrite ^/fr/dev/django-3eme-partie-les-templates-et-bien-dautres-choses/$ http://localhost/blog/dev/django-3eme-partie-les-templates-et-bien-dautres-choses permanent;
rewrite ^/fr/tags/django/$ http://localhost/blog/tag/django permanent;
rewrite ^/fr/tags/mvc/$ http://localhost/blog/tag/mvc permanent;
rewrite ^/fr/tags/python/$ http://localhost/blog/tag/python permanent;
rewrite ^/fr/dev/django-2nde-partie-le-modele-et-ladmin/$ http://localhost/blog/dev/django-2nde-partie-le-modele-et-ladmin permanent;
rewrite ^/fr/infra/creer-une-autorite-de-certification-et-des-certificats-ssl-auto-signes/$ http://localhost/blog/infra/creer-une-autorite-de-certification-et-des-certificats-ssl-auto-signes permanent;
rewrite ^/fr/dev/premiers-pas-avec-le-framework-python-django/$ http://localhost/blog/dev/premiers-pas-avec-le-framework-python-django permanent;
rewrite ^/fr/dev/installation-et-premiers-pas-avec-le-plugin-symfony-sfimagetransformextraplugin/$ http://localhost/blog/dev/installation-et-premiers-pas-avec-le-plugin-symfony-sfimagetransformextraplugin permanent;
rewrite ^/fr/dev/symfony-2-linjection-de-dependances/$ http://localhost/blog/dev/symfony-2-linjection-de-dependances permanent;
rewrite ^/fr/tech/configuration-de-bind-sous-mac-os-x/$ http://localhost/blog/tech/configuration-de-bind-sous-mac-os-x permanent;
rewrite ^/fr/tags/bind/$ http://localhost/blog/tag/bind permanent;
rewrite ^/fr/tags/mac-osx/$ http://localhost/blog/tag/mac-osx permanent;
rewrite ^/fr/dev/propel-utiliser-des-champs-calcules/$ http://localhost/blog/dev/propel-utiliser-des-champs-calcules permanent;
rewrite ^/fr/tags/propel/$ http://localhost/blog/tag/propel permanent;
rewrite ^/fr/tags/orm/$ http://localhost/blog/tag/orm permanent;
rewrite ^/fr/infra/utilisation-de-la-commande-find-cas-pratiques/$ http://localhost/blog/infra/utilisation-de-la-commande-find-cas-pratiques permanent;
rewrite ^/fr/infra/authentifications-multiples-a-partir-de-cles-ssh/$ http://localhost/blog/infra/authentifications-multiples-a-partir-de-cles-ssh permanent;
rewrite ^/fr/infra/securiser-ses-acces-serveur-authentification-par-cles-ssh/$ http://localhost/blog/infra/securiser-ses-acces-serveur-authentification-par-cles-ssh permanent;
rewrite ^/fr/infra/installation-de-fuse-et-s3fs-sur-une-debian-lenny/$ http://localhost/blog/infra/installation-de-fuse-et-s3fs-sur-une-debian-lenny permanent;
rewrite ^/fr/tags/fuse/$ http://localhost/blog/tag/fuse permanent;
rewrite ^/fr/tags/s3fs/$ http://localhost/blog/tag/s3fs permanent;
rewrite ^/fr/infra/syntaxe-des-enregistrements-spf-sender-privacy-framework/$ http://localhost/blog/infra/syntaxe-des-enregistrements-spf-sender-privacy-framework permanent;
rewrite ^/fr/tags/spf/$ http://localhost/blog/tag/spf permanent;
rewrite ^/fr/infra/operation-sur-un-fichier-avec-la-commande-find/$ http://localhost/blog/infra/operation-sur-un-fichier-avec-la-commande-find permanent;
rewrite ^/fr/infra/installation-d-un-depot-svn/$ http://localhost/blog/infra/installation-d-un-depot-svn permanent;
rewrite ^/fr/tags/svn/$ http://localhost/blog/tag/svn permanent;
```