### PR TITLE
Slugify tags (to avoid white spaces).

### DIFF
--- a/src/Model/Article.php
+++ b/src/Model/Article.php
@@ -46,7 +46,7 @@ class Article
 
     public function hasTag(string $tag): bool
     {
-        return \in_array(strtolower($tag), array_map('strtolower', $this->tags), true);
+        return \in_array($tag, $this->tags, true);
     }
 
     public function hasAuthor(Member $author, int $maxAuthors = 0): bool

--- a/src/Stenope/Processor/TagProcessor.php
+++ b/src/Stenope/Processor/TagProcessor.php
@@ -31,6 +31,11 @@ class TagProcessor implements ProcessorInterface, ContentManagerAwareInterface
             return;
         }
 
-        $data['tags'] = array_map([$this->slugger, 'slug'], $data['tags']);
+        $data['tags'] = array_map([$this, 'slugify'], $data['tags']);
+    }
+
+    private function slugify(string $tag): string
+    {
+        return $this->slugger->slug($tag)->lower()->toString();
     }
 }

--- a/templates/blog/article.html.twig
+++ b/templates/blog/article.html.twig
@@ -60,7 +60,7 @@
             <ul class="article-tag-list">
                 {% for tag in article.tags %}
                     <li class="article-tag-list__item">
-                        <a href="{{ path('blog_tag', { tag: tag|lower }) }}" rel="nofollow">#{{ tag|u.title }}</a>
+                        <a href="{{ path('blog_tag', { tag: tag }) }}" rel="nofollow">#{{ tag|u.camel.title }}</a>
                     </li>
                 {% endfor %}
             </ul>

--- a/templates/blog/index.html.twig
+++ b/templates/blog/index.html.twig
@@ -57,8 +57,8 @@
                                 <ul class="tag-list">
                                     {% for tag in article.tags %}
                                         <li class="tag-list__item">
-                                            <a href="{{ path('blog_tag', { tag: tag|lower }) }}" rel="nofollow">
-                                                #{{ tag|u.title }}
+                                            <a href="{{ path('blog_tag', { tag: tag }) }}" rel="nofollow">
+                                                #{{ tag|u.camel.title }}
                                             </a>
                                         </li>
                                     {% endfor %}

--- a/templates/blog/tag.html.twig
+++ b/templates/blog/tag.html.twig
@@ -12,7 +12,7 @@
         </li>
         <li class="breadcrumb__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
             <a itemprop="item" href="#">
-                <span itemprop="name">#{{ tag|u.title }}</span>
+                <span itemprop="name">#{{ tag|u.camel.title }}</span>
             </a>
             <meta itemprop="position" content="2"/>
         </li>
@@ -23,8 +23,6 @@
     {% include 'blog/pagination.html.twig' with {
         route: 'blog_tag_page',
         minPageRoute: 'blog_tag',
-        routeParams: {
-            tag: tag|lower,
-        }
+        routeParams: { tag: tag }
     } %}
 {% endblock content %}


### PR DESCRIPTION
Qu'en pensez vous ? 

C'est notamment pour éviter ça : https://www.elao.com/blog/tag/react%20native 

--- 

- [x] Les tags sont normalisé lowercase + tiret en amont 
- [x] Les tags sont affichés en camel case

---

### Url : 
```
/blog/tag/progressive-web-app
```

### Page article : 
![Capture d’écran 2021-04-20 à 09 03 37](https://user-images.githubusercontent.com/1846873/115352324-85c06e00-a1b7-11eb-8a63-f59037873bf1.png)

### Liste des articles : 
![Capture d’écran 2021-04-20 à 08 59 49](https://user-images.githubusercontent.com/1846873/115352337-88bb5e80-a1b7-11eb-9a16-80415f1daec0.png)

### Page Tag : 
![Capture d’écran 2021-04-20 à 08 59 37](https://user-images.githubusercontent.com/1846873/115352350-8bb64f00-a1b7-11eb-8811-3eea9812e466.png)

