### PR TITLE
Fix logo height in signature

### DIFF
--- a/templates/team/mail_signature.html.twig
+++ b/templates/team/mail_signature.html.twig
@@ -33,7 +33,7 @@
     <tbody>
         <tr>
             <td style="padding-top: 5px; padding-right: 15px; vertical-align: top;">
-                <img src="https://ci3.googleusercontent.com/proxy/wWcaMkX1ZCFxHJc4AZ9ZULFlSjo2mdBUbue0c3DlCEvy57fryn_v4OicxkwsHJPZKltVkss77c6dS1wLg5wN3bAV2siGoQ=s0-d-e1-ft#http://www.elao.com/images/corpo/logo-email-signature.png" alt="logo elao" width="50" height="18" style="width: 50px; height: 18px">
+                <img src="https://ci3.googleusercontent.com/proxy/wWcaMkX1ZCFxHJc4AZ9ZULFlSjo2mdBUbue0c3DlCEvy57fryn_v4OicxkwsHJPZKltVkss77c6dS1wLg5wN3bAV2siGoQ=s0-d-e1-ft#http://www.elao.com/images/corpo/logo-email-signature.png" alt="logo elao" width="45" height="16" style="width: 45px; height: 16px">
             </td>
             <td>
                 <strong style="font-family: Courier, sans-serif; font-size: 14px; font-weight: bold; color: #ff4344; line-height: 20px;">{{ member.name|split(' ', 2)[0] }} <span style="color: #7f1a55;">{{ member.name|split(' ', 2)[1] }}</span></strong>


### PR DESCRIPTION
<img width="453" alt="Capture d’écran 2021-04-28 à 13 35 46" src="https://user-images.githubusercontent.com/25897625/116397259-ad9e7a00-a826-11eb-8b50-f493ed85621d.png">
