### PR TITLE
[Article] Fix date de dernière modification + allow different banner img

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1455,12 +1455,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/StenopePHP/Stenope.git",
-                "reference": "77747fd164cc68ccf5db0b91586f7eb1e057dfef"
+                "reference": "d6353683b0d6710f869c16512b83e7f6e09bc2ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/StenopePHP/Stenope/zipball/77747fd164cc68ccf5db0b91586f7eb1e057dfef",
-                "reference": "77747fd164cc68ccf5db0b91586f7eb1e057dfef",
+                "url": "https://api.github.com/repos/StenopePHP/Stenope/zipball/d6353683b0d6710f869c16512b83e7f6e09bc2ed",
+                "reference": "d6353683b0d6710f869c16512b83e7f6e09bc2ed",
                 "shasum": ""
             },
             "require": {
@@ -1478,6 +1478,7 @@
                 "symfony/finder": "^5.1",
                 "symfony/http-foundation": "^5.1",
                 "symfony/http-kernel": "^5.1",
+                "symfony/mime": "^5.1",
                 "symfony/process": "^5.1",
                 "symfony/property-access": "^5.1",
                 "symfony/routing": "^5.1",
@@ -1536,7 +1537,7 @@
                 "issues": "https://github.com/StenopePHP/Stenope/issues",
                 "source": "https://github.com/StenopePHP/Stenope/tree/master"
             },
-            "time": "2021-03-31T12:29:56+00:00"
+            "time": "2021-05-03T15:43:11+00:00"
         },
         {
             "name": "symfony/asset",

--- a/content/blog/dev/a-nice-way-of-handing-form-label-translation.md
+++ b/content/blog/dev/a-nice-way-of-handing-form-label-translation.md
@@ -3,9 +3,8 @@
 type:               "post"
 title:              "A nice way of handling form label translation"
 date:               "2013-09-13"
-publishdate:        "2013-09-13"
+lastModified:       ~
 lang:               "en"
-draft:              false
 
 description:        "A nice way of handling form label translation"
 

--- a/content/blog/dev/ameliorez-pertinence-resultat-elastic-search-score.md
+++ b/content/blog/dev/ameliorez-pertinence-resultat-elastic-search-score.md
@@ -1,14 +1,13 @@
 ---
 type:           "post"
 title:          "Améliorez la pertinence de vos résultats ElasticSearch grâce au score"
-date:           "2017-04-24"
-publishdate:    "2017-04-27"
-draft:          false
+date:           "2017-04-27"
+lastModified:       ~
 
 description:    "Améliorez la pertinence de vos résultats ElasticSearch grâce au score."
 
 thumbnail:      "images/posts/thumbnails/elasticsearch.png"
-header_img:     "images/posts/headers/elasticsearch.jpg"
+banner:     "images/posts/headers/elasticsearch.jpg"
 tags:           ["Moteur de recherche", "ElasticSearch", "Pertinence", "Elastica"]
 categories:     ["dev"]
 

--- a/content/blog/dev/api-design-elao-team-interview.md
+++ b/content/blog/dev/api-design-elao-team-interview.md
@@ -2,14 +2,13 @@
 type:               "post"
 title:              "Conception et développement d'API : l'interview croisée de l'équipe Élao"
 date:               "2017-11-27"
-publishdate:        "2017-11-27"
-draft:              false
+lastModified:       ~
 
 description:        "Interview croisée des développeurs d'Élao à propos de leurs diverses expériences en conception et développement d'API"
 tableOfContent:     2
 
 thumbnail:          "images/posts/thumbnails/api-interview-micro-phone.png"
-header_img:         "images/posts/headers/api-interview-micro-phone.png"
+banner:             "images/posts/headers/api-interview-micro-phone.png"
 tags:               ["API", "Conception", "REST", "API Design"]
 categories:         ["Dev"]
 

--- a/content/blog/dev/apollo-graphql-cache.md
+++ b/content/blog/dev/apollo-graphql-cache.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Comprendre le cache du client Graphql Apollo"
 date:               "2020-02-17"
-publishdate:        "2020-02-17"
-draft:              false
+lastModified:       ~
 
 description:        "Découverte du fonctionnement du cache du client GraphQL Apollo."
 
 thumbnail:          "images/posts/thumbnails/graphql-apollo.jpg"
-header_img:         "images/posts/headers/graphql-apollo.jpg"
+banner:             "images/posts/headers/graphql-apollo.jpg"
 tags:               ["GraphQL","Cache","Apollo","Javascript","API"]
 categories:         ["Dev", "Javascript"]
 

--- a/content/blog/dev/architecture-hexagonale-symfony.md
+++ b/content/blog/dev/architecture-hexagonale-symfony.md
@@ -1,15 +1,14 @@
 ---
 type:               "post"
 title:              "L'architecture hexagonale avec Symfony"
-date:               "2017-06-05"
-publishdate:        "2017-06-21"
-draft:              false
+date:               "2017-06-21"
+lastModified:       ~
 
 description:        "Présentation de l'architecture hexagonale et de son implémentation avec le framework Symfony."
 tableOfContent:     3
 
 thumbnail:          "images/posts/thumbnails/hexagons.jpg"
-header_img:         "images/posts/headers/hexagons.jpg"
+banner:             "images/posts/headers/hexagons.jpg"
 tags:               ["Architecture", "Conception", "Symfony", "PHP"]
 categories:         ["Dev", "Symfony"]
 

--- a/content/blog/dev/authentification-par-lien-magique.md
+++ b/content/blog/dev/authentification-par-lien-magique.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Authentification par lien magique"
 date:               "2018-03-14"
-publishdate:        "2018-03-14"
-draft:              false
+lastModified:       ~
 
 description:        "Retour d'expérience sur la mise en place d'authentification par lien de connexion."
 
 thumbnail:          "images/posts/thumbnails/magic-link.jpg"
-header_img:         "images/posts/headers/magic-link.jpg"
+banner:             "images/posts/headers/magic-link.jpg"
 tags:               ["Authentification", "Email", "Sécurité", "MagicLink"]
 categories:         ["Dev"]
 

--- a/content/blog/dev/behat-3-test-fonctionnel-symfony.md
+++ b/content/blog/dev/behat-3-test-fonctionnel-symfony.md
@@ -1,14 +1,13 @@
 ---
 type:               "post"
 title:              "Behat 3 pour vos tests fonctionnels Symfony2"
-date:               "2015-10-23"
-publishdate:        "2016-01-06"
-draft:              false
+date:               "2016-01-06"
+lastModified:       ~
 
 description:        "Installation et utilisation de Behat 3 pour vos tests fonctionnels Symfony2"
 
 thumbnail:          "images/posts/thumbnails/behat.png"
-header_img:         "images/posts/headers/behat_cover.jpg"
+banner:             "images/posts/headers/behat_cover.jpg"
 tags:               ["Behat","Symfony","Mink","Alice"]
 categories:         ["Dev", Symfony", "PHP"]
 

--- a/content/blog/dev/bonnes-pratiques-symfony2-notre-condense.md
+++ b/content/blog/dev/bonnes-pratiques-symfony2-notre-condense.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Bonnes pratiques Symfony2 : notre condensé !"
 date:               "2013-04-19"
-publishdate:        "2013-04-19"
-draft:              false
+lastModified:       ~
 
 description:        "Bonnes pratiques Symfony2 : notre condensé !"
 
 thumbnail:          "images/posts/thumbnails/kafeine.png"
-header_img:         "images/posts/headers/elephpant_elao_family.jpg"
+banner:             "images/posts/headers/elephpant_elao_family.jpg"
 tags:               ["Tips", "Symfony"]
 categories:         ["Tips", "Symfony"]
 

--- a/content/blog/dev/commander-au-clavier-app-symfony-grace-au-routing.md
+++ b/content/blog/dev/commander-au-clavier-app-symfony-grace-au-routing.md
@@ -2,14 +2,13 @@
 type:           "post"
 title:          "Commander au clavier une application Symfony grâce au Routing"
 date:           "2018-10-25"
-publishdate:    "2018-10-25"
-draft:          false
+lastModified:       ~
 
 description:    "Comment ajouter à une application Symfony une UI différente, une interface de commande par texte avec autocompletion."
 tableOfContent: 2
 
 thumbnail:      "images/posts/2018/commander-au-clavier-app-symfony-grace-au-routing/thumbnail.jpg"
-header_img:     "images/posts/2018/commander-au-clavier-app-symfony-grace-au-routing/header.jpg"
+banner:     "images/posts/2018/commander-au-clavier-app-symfony-grace-au-routing/header.jpg"
 tags:           ["Symfony", "Routing", "UX"]
 categories:     ["dev", "Symfony"]
 

--- a/content/blog/dev/comment-demarrer-tdd-en-php.md
+++ b/content/blog/dev/comment-demarrer-tdd-en-php.md
@@ -2,14 +2,13 @@
 type:               "post"
 title:              "Comment démarrer en TDD en PHP ?"
 date:               "2018-10-30"
-publishdate:        "2018-10-30"
-draft:              false
+lastModified:       ~
 
 description:        "Test Driven Development c'est bien mais comment commencer à en faire ?"
 tableOfContent:     2
 
 thumbnail:          "images/posts/thumbnails/tdd.jpg"
-header_img:         "images/posts/headers/tdd.jpg"
+banner:             "images/posts/headers/tdd.jpg"
 tags:               ["PHP", "Test", "TDD"]
 categories:         ["Dev", "PHP"]
 

--- a/content/blog/dev/comment-integrer-vue-js-application-symfony.md
+++ b/content/blog/dev/comment-integrer-vue-js-application-symfony.md
@@ -2,14 +2,13 @@
 type:               "post"
 title:              "Comment intégrer Vue.js dans une application Symfony"
 date:               "2016-10-21"
-publishdate:        "2016-10-21"
+lastModified:       ~
 modifieddate:       "2020-05-05"
-draft:              false
 
 description:        "Guide d'intrégration de Vue.js dans une application Symfony"
 
 thumbnail:          "images/posts/thumbnails/vuejs.jpg"
-header_img:         "images/posts/headers/vuejs.jpg"
+banner:             "images/posts/headers/vuejs.jpg"
 tags:               ["Vuejs","Javascript","Frontend","Symfony"]
 categories:         ["Dev", "Vuejs", "Javascript", "Symfony"]
 

--- a/content/blog/dev/date-php-timezone-utc-pourquoi-est-ce-important.md
+++ b/content/blog/dev/date-php-timezone-utc-pourquoi-est-ce-important.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Dates PHP et Timezone UTC, pourquoi est-ce important ?"
 date:               "2017-11-21"
-publishdate:        "2017-11-21"
-draft:              false
+lastModified:       ~
 
 description:        "Mise au point sur les problématiques de timezone avec les dates PHP."
 
 thumbnail:          "images/posts/thumbnails/time.jpg"
-header_img:         "images/posts/headers/time.jpg"
+banner:             "images/posts/headers/time.jpg"
 tags:               ["Symfony", "PHP","Datetime", "Timezone"]
 categories:         ["Dev", "Symfony", "PHP"]
 

--- a/content/blog/dev/design-pattern-abstract-factory.md
+++ b/content/blog/dev/design-pattern-abstract-factory.md
@@ -2,13 +2,12 @@
 type:           "post"
 title:          "Le Design Pattern 'Abstract Factory'"
 date:           "2017-04-11"
-publishdate:    "2017-04-11"
-draft:          false
+lastModified:       ~
 
 description:    "Deuxième article d'une série consacrée aux Design Patterns. Aujourd'hui : le pattern Abstract Factory"
 
 thumbnail:      "images/posts/thumbnails/schema.jpg"
-header_img:     "images/posts/headers/header_schema.jpg"
+banner:     "images/posts/headers/header_schema.jpg"
 tags:           ["Design Pattern", "Conception"]
 categories:     ["Dev", "Design Pattern"]
 

--- a/content/blog/dev/design-pattern-chain-of-responsibility.md
+++ b/content/blog/dev/design-pattern-chain-of-responsibility.md
@@ -2,13 +2,12 @@
 type:           "post"
 title:          "Le Design Pattern 'Chain of Responsibility'"
 date:           "2017-05-13"
-publishdate:    "2017-05-13"
-draft:          false
+lastModified:       ~
 
 description:    "Nouvel article consacré aux Design Patterns. Aujourd'hui : le pattern Chain of Responsibility"
 
 thumbnail:      "images/posts/thumbnails/chaplin-assembly-line.jpeg"
-header_img:     "images/posts/headers/chaplin-assembly-line.jpg"
+banner:     "images/posts/headers/chaplin-assembly-line.jpg"
 tags:           ["Design Pattern", "Conception"]
 categories:     ["Dev", "Design Pattern"]
 

--- a/content/blog/dev/design-pattern-decorator.md
+++ b/content/blog/dev/design-pattern-decorator.md
@@ -1,14 +1,13 @@
 ---
 type:           "post"
 title:          "Le Design Pattern 'Decorator'"
-date:           "2017-04-14"
-publishdate:    "2017-05-04"
-draft:          false
+date:           "2017-05-04"
+lastModified:       ~
 
 description:    "Présentation du pattern 'Decorator' dans le cadre d'une série consacrée aux Design Patterns"
 
 thumbnail:      "images/posts/thumbnails/decorator_pattern.jpg"
-header_img:     "images/posts/headers/decorator_pattern.jpg"
+banner:     "images/posts/headers/decorator_pattern.jpg"
 tags:           ["Design Pattern", "Conception"]
 categories:     ["Dev", "Design Pattern"]
 

--- a/content/blog/dev/design-pattern-factory-method.md
+++ b/content/blog/dev/design-pattern-factory-method.md
@@ -2,13 +2,12 @@
 type:           "post"
 title:          "Le Design Pattern 'Factory Method'"
 date:           "2017-04-10"
-publishdate:    "2017-04-10"
-draft:          false
+lastModified:       ~
 
 description:    "Premier article d'une série consacrée aux Design Patterns. Aujourd'hui : le pattern Factory Method"
 
 thumbnail:      "images/posts/thumbnails/scientist.jpg"
-header_img:     "images/posts/headers/scientist.jpg"
+banner:     "images/posts/headers/scientist.jpg"
 tags:           ["Design Pattern", "Conception"]
 categories:     ["Dev", "Design Pattern"]
 

--- a/content/blog/dev/django-2nde-partie-le-modele-et-ladmin.md
+++ b/content/blog/dev/django-2nde-partie-le-modele-et-ladmin.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Django (2nde partie) : le Modèle et l’Admin"
 date:               "2010-10-06"
-publishdate:        "2010-10-06"
-draft:              false
+lastModified:       ~
 
 description:        "Django (2nde partie) : le Modèle et l’Admin"
 

--- a/content/blog/dev/django-3eme-partie-les-templates-et-bien-dautres-choses.md
+++ b/content/blog/dev/django-3eme-partie-les-templates-et-bien-dautres-choses.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Django (3ème partie) : les templates, et bien d'autres choses ..."
 date:               "2010-10-15"
-publishdate:        "2010-10-15"
-draft:              false
+lastModified:       ~
 
 description:        "Django (3ème partie) : les templates, et bien d'autres choses ..."
 

--- a/content/blog/dev/donnees-structurees-offre-emploi.md
+++ b/content/blog/dev/donnees-structurees-offre-emploi.md
@@ -1,14 +1,12 @@
 ---
 type:               "post"
 title:              "Mettez en valeur vos offres d'emploi grâce aux données structurées"
-date:               "2019-08-26"
 tableOfContent:     2
-draft:              false
 
 description:        "Et si vous rendiez vos offres d'emploi plus visibles dans les pages de résultats des moteurs de recherche grâce aux données structurées ? "
 
 thumbnail:          "images/posts/thumbnails/arrows-square.jpg"
-header_img:         "images/posts/headers/arrows.jpg"
+banner:             "images/posts/headers/arrows.jpg"
 tags:               ["Seo", "microdata", "rich snippets"]
 categories:         ["Dev", "Web"]
 

--- a/content/blog/dev/ecrire-des-tests-behat-proches-de-son-domaine.md
+++ b/content/blog/dev/ecrire-des-tests-behat-proches-de-son-domaine.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Écrire des tests Behat proches de son domaine"
 date:               "2018-06-17"
-publishdate:        "2018-06-17"
-draft:              false
+lastModified:       ~
 
 description:        ""
 
 thumbnail:          "images/posts/thumbnails/ecrire-des-tests-behat-proche-de-son-domaine-thumbnail.png"
-header_img:         "images/posts/headers/ecrire-test-behat-proche-de-son-domaine.jpg"
+banner:             "images/posts/headers/ecrire-test-behat-proche-de-son-domaine.jpg"
 tags:               ["Behat","Symfony","DDD"]
 categories:         ["Dev", Symfony", "PHP"]
 

--- a/content/blog/dev/from-react-native-init-to-app-stores-real-quick.md
+++ b/content/blog/dev/from-react-native-init-to-app-stores-real-quick.md
@@ -2,15 +2,14 @@
 type:           "post"
 title:          "From react-native init to app stores real quick"
 date:           "2017-11-09"
-publishdate:    "2017-11-09"
+lastModified:       ~
 lang:           "en"
-draft:          false
 
 description:    "From react-native init to stores real quick"
 tableOfContent: 3
 
 thumbnail:      "images/posts/thumbnails/from-react-native-init-to-app-stores-real-quick.jpg"
-header_img:     "images/posts/headers/from-react-native-init-to-app-stores-real-quick.jpg"
+banner:     "images/posts/headers/from-react-native-init-to-app-stores-real-quick.jpg"
 tags:           ["react", "react native", "mobile"]
 categories:     ["dev"]
 

--- a/content/blog/dev/how-to-manage-translations-for-your-object-using-sonataadminbundle.md
+++ b/content/blog/dev/how-to-manage-translations-for-your-object-using-sonataadminbundle.md
@@ -2,9 +2,8 @@
 type:               "post"
 title:              "How to manage translations for your object using SonataAdminBundle"
 date:               "2012-07-27"
-publishdate:        "2012-07-27"
+lastModified:       ~
 lang:               "en"
-draft:              false
 
 description:        "How to manage translations for your object using SonataAdminBundle"
 

--- a/content/blog/dev/installation-et-premiers-pas-avec-le-plugin-symfony-sfimagetransformextraplugin.md
+++ b/content/blog/dev/installation-et-premiers-pas-avec-le-plugin-symfony-sfimagetransformextraplugin.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Installation et premiers pas avec le plugin Symfony sfImageTransformExtraPlugin"
 date:               "2010-07-12"
-publishdate:        "2010-07-12"
-draft:              false
+lastModified:       ~
 
 description:        "Installation et premiers pas avec le plugin Symfony sfImageTransformExtraPlugin."
 

--- a/content/blog/dev/la-revanche-du-web-par-les-progressive-web-apps.md
+++ b/content/blog/dev/la-revanche-du-web-par-les-progressive-web-apps.md
@@ -2,13 +2,12 @@
 type:           "post"
 title:          "Le web n'est pas mort, la revanche par les Progressives Web Apps"
 date:           "2016-12-05"
-publishdate:    "2016-12-05"
-draft:          false
+lastModified:       ~
 
 description:    "Les Progressives Web Apps ont pour objectif de rivaliser avec les apps natives. Voyons comment cela fonctionne et le gain que cela apporte à vos utilisateurs."
 
 thumbnail:      "images/posts/thumbnails/pwa-general.jpg"
-header_img:     "images/posts/2016/pwa/pwa-general.jpg"
+banner:     "images/posts/2016/pwa/pwa-general.jpg"
 tags:           ["Progressive Web App", "Service Worker", "Mobile", "Offline"]
 categories:     ["dev"]
 

--- a/content/blog/dev/maintenabilite-et-performance-avec-sass-et-compass.md
+++ b/content/blog/dev/maintenabilite-et-performance-avec-sass-et-compass.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Maintenabilité et performance avec Sass et Compass"
 date:               "2013-04-09"
-publishdate:        "2013-04-09"
-draft:              false
+lastModified:       ~
 
 description:        "Maintenabilité et performance avec Sass et Compass"
 
 thumbnail:          "images/posts/thumbnails/sass.png"
-header_img:         "images/posts/headers/elao_team_front.jpg"
+banner:             "images/posts/headers/elao_team_front.jpg"
 tags:               ["CSS", "Webdesign", "Développement"]
 categories:         ["Dev", "Web", "CSS", "Webdesign"]
 

--- a/content/blog/dev/manalize-virtualiser-son-environnement-de-developpement.md
+++ b/content/blog/dev/manalize-virtualiser-son-environnement-de-developpement.md
@@ -2,12 +2,11 @@
 type:               "post"
 title:              "Virtualiser son environnement de développement avec Manalize ✨"
 date:               "2019-01-29"
-publishdate:        "2019-01-29"
-draft:              false
+lastModified:       ~
 tableOfContent:     2
 
 description:        "Virtualiser son environnement de développement avec Manalize ✨"
-header_img:         "images/posts/headers/manalize-virtualiser-son-environnement-de-developpement.jpg"
+banner:             "images/posts/headers/manalize-virtualiser-son-environnement-de-developpement.jpg"
 thumbnail:          "images/posts/thumbnails/manalize-virtualiser-son-environnement-de-developpement.jpg"
 credits:            { name: 'Mark Mühlberger', url: 'https://unsplash.com/photos/zen35Y3B834' }
 tags:               ["manala", "virtualisation", "ansible", "vagrant",]

--- a/content/blog/dev/meteor-multi-apps-architecture.md
+++ b/content/blog/dev/meteor-multi-apps-architecture.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Meteor - Archi. multi-apps connectées"
 date:               "2015-06-23"
-publishdate:        "2015-06-23"
-draft:              false
+lastModified:       ~
 
 description:        "Architecture d'une application Meteor décomposée en plusieurs sous-applications connectées à la même base de données MongoDb."
 
 thumbnail:          "images/posts/thumbnails/beer.jpg"
-header_img:         "images/posts/headers/elephpant_elao.jpg"
+banner:             "images/posts/headers/elephpant_elao.jpg"
 tags:               ["Meteor", "Tips", "Développement", "Bonnes pratiques"]
 categories:         ["Web", "Meteor"]
 

--- a/content/blog/dev/migrer-mots-de-passe-utilisateur-autre-methode-encodage-symfony.md
+++ b/content/blog/dev/migrer-mots-de-passe-utilisateur-autre-methode-encodage-symfony.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Migrer les mots de passe utilisateur vers une autre méthode d'encodage avec Symfony"
 date:               "2017-09-12"
-publishdate:        "2017-09-12"
-draft:              false
+lastModified:       ~
 
 description:        "Migration continue de mots de passe legacy d'une méthode d'encodage à une autre dans Symfony. Par exemple, migrer de md5 vers bcrypt."
 
 thumbnail:          "images/posts/thumbnails/password.jpg"
-header_img:         "images/posts/headers/password.jpg"
+banner:             "images/posts/headers/password.jpg"
 tags:               ["Sécurité", "Migration", "Encodage", "Symfony"]
 categories:         ["Dev", "Symfony"]
 

--- a/content/blog/dev/no-index-staging-symfony.md
+++ b/content/blog/dev/no-index-staging-symfony.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Comment empêcher les moteurs de recherche d'indexer votre app Symfony en staging ?"
 date:               "2019-07-10"
-publishdate:        "2019-07-10"
-draft:              false
+lastModified:       ~
 
 description:        "Les pages de votre application n'ont pas vocation à être présentes dans les moteurs de recherche ? Voici une courte explication pour vous aider à empêcher le crawl et l'indexation."
 
 thumbnail:          "images/posts/thumbnails/judging-sardine-small.jpg"
-header_img:         "images/posts/headers/judging-sardine-large.jpg"
+banner:             "images/posts/headers/judging-sardine-large.jpg"
 tags:               ["Symfony", "seo", "no-index"]
 categories:         ["Dev", "Symfony", "seo"]
 author:             ["mcolin", "aldeboissieu"]

--- a/content/blog/dev/offusquez-vos-id-dans-vos-url.md
+++ b/content/blog/dev/offusquez-vos-id-dans-vos-url.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Offusquez vos id dans vos url"
 date:               "2019-11-06"
-publishdate:        "2019-11-06"
-draft:              false
+lastModified:       ~
 
 description:        "Découverte d'alternatives aux ID auto-incrémentés dans les urls et leur mise en place dans le framework Symfony."
 
 thumbnail:          "images/posts/thumbnails/obfuscation.jpg"
-header_img:         "images/posts/headers/obfuscation.jpg"
+banner:             "images/posts/headers/obfuscation.jpg"
 tags:               ["Securite","PHP","Symfony","Framework"]
 categories:         ["Dev", "Symfony"]
 

--- a/content/blog/dev/planification-de-rdv-avec-optaplanner.md
+++ b/content/blog/dev/planification-de-rdv-avec-optaplanner.md
@@ -2,13 +2,12 @@
 type:           "post"
 title:          "Planification de rendez-vous avec OptaPlanner"
 date:           "2017-10-10"
-publishdate:    "2017-10-10"
-draft:          false
+lastModified:       ~
 
 description:    ""
 
 thumbnail:      "images/posts/2017/planification-de-rdv-avec-optaplanner/optaplanner-teacher-agenda.png"
-header_img:     "images/posts/2017/planification-de-rdv-avec-optaplanner/optaplanner-logo.png"
+banner:     "images/posts/2017/planification-de-rdv-avec-optaplanner/optaplanner-logo.png"
 tags:           ["Planification", "OptaPlanner"]
 categories:     ["dev"]
 

--- a/content/blog/dev/plusieurs-mailer-dans-une-application-symfony-2.md
+++ b/content/blog/dev/plusieurs-mailer-dans-une-application-symfony-2.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Plusieurs mailer dans une application Symfony 2"
 date:               "2013-10-11"
-publishdate:        "2013-10-11"
-draft:              false
+lastModified:       ~
 
 description:        "Plusieurs mailer dans une application Symfony 2"
 

--- a/content/blog/dev/pourquoi-devriez-vous-utiliser-vue-js-dans-vos-projets.md
+++ b/content/blog/dev/pourquoi-devriez-vous-utiliser-vue-js-dans-vos-projets.md
@@ -1,14 +1,13 @@
 ---
 type:               "post"
 title:              "Pourquoi devriez-vous utiliser Vue.js dans vos projets ?"
-date:               "2016-10-17"
-publishdate:        "2016-10-19"
-draft:              false
+date:               "2016-10-19"
+lastModified:       ~
 
 description:        "Retour d'expérience sur le framework frontend Vue.js et pourquoi l'utiliser"
 
 thumbnail:          "images/posts/thumbnails/vuejs.jpg"
-header_img:         "images/posts/headers/vuejs.jpg"
+banner:             "images/posts/headers/vuejs.jpg"
 tags:               ["Vuejs","Javascript","Frontend","Framework"]
 categories:         ["Dev", "Vuejs", "Javascript"]
 

--- a/content/blog/dev/premiers-pas-avec-le-framework-python-django.md
+++ b/content/blog/dev/premiers-pas-avec-le-framework-python-django.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Premiers pas avec le framework Python \"Django\""
 date:               "2010-09-15"
-publishdate:        "2010-09-15"
-draft:              false
+lastModified:       ~
 
 description:        "Premiers pas avec le framework Python \"Django\""
 

--- a/content/blog/dev/progressive-web-app-chalkboard-education-elearning-sans-internet.md
+++ b/content/blog/dev/progressive-web-app-chalkboard-education-elearning-sans-internet.md
@@ -2,14 +2,13 @@
 type:           "post"
 title:          "E-learning sans internet ou presque"
 date:           "2017-11-22"
-publishdate:    "2017-11-22"
-draft:          false
+lastModified:       ~
 
 description:    "Retour d'expérience sur la conception de la progressive web app de Chalkboard Education"
 tableOfContent: 3
 
 thumbnail:      "images/posts/2017/chalkboard-education/woman-phone.jpg"
-header_img:     "images/posts/2017/chalkboard-education/woman-phone.jpg"
+banner:     "images/posts/2017/chalkboard-education/woman-phone.jpg"
 tags:           ["Progressive Web App", "Offline", "React", "Symfony"]
 categories:     ["dev", "Symfony", "javascript"]
 

--- a/content/blog/dev/propel-utiliser-des-champs-calcules.md
+++ b/content/blog/dev/propel-utiliser-des-champs-calcules.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Propel - Utiliser des champs calculés"
 date:               "2010-05-13"
-publishdate:        "2010-05-13"
-draft:              false
+lastModified:       ~
 
 description:        "Propel - Utiliser des champs calculés"
 

--- a/content/blog/dev/react-native-font-icon.md
+++ b/content/blog/dev/react-native-font-icon.md
@@ -1,15 +1,14 @@
 ---
 type:           "post"
 title:          "Intégrer des icônes vectorielles dans React Native"
-date:           "2018-03-02"
-publishdate:    "2018-03-06"
-draft:          false
+date:           "2018-03-06"
+lastModified:       ~
 tableOfContent: 2
 
 description:    "Comment intégrer des icônes vectorielles dans une app React Native grâce à une police de caractères personnalisée."
 thumbnail:      "images/posts/thumbnails/harpal-singh-396280-unsplash.jpg"
 credits:        { name: "Harpal Singh", url: "https://unsplash.com/@aquatium" }
-header_img:     "images/posts/headers/harpal-singh-396280-unsplash.jpg"
+banner:     "images/posts/headers/harpal-singh-396280-unsplash.jpg"
 tags:           ["React native", "Mobile", "Font", "Icon"]
 categories:     ["dev"]
 

--- a/content/blog/dev/realisez-une-application-vue-js-avec-vue-cli.md
+++ b/content/blog/dev/realisez-une-application-vue-js-avec-vue-cli.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Réalisez une application Vue.js avec vue-cli"
 date:               "2016-11-04"
-publishdate:        "2016-11-04"
-draft:              false
+lastModified:       ~
 
 description:        "Introduction à la réalisation d'applications frontend avec Vue.js et vue-cli."
 
 thumbnail:          "images/posts/thumbnails/vuejs.jpg"
-header_img:         "images/posts/headers/vuejs.jpg"
+banner:             "images/posts/headers/vuejs.jpg"
 tags:               ["Vuejs","Javascript","Front","Framework"]
 categories:         ["Dev", "Vuejs", "Javascript", "Symfony"]
 

--- a/content/blog/dev/responsive-web-design.md
+++ b/content/blog/dev/responsive-web-design.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Responsive Web Design"
 date:               "2012-07-31"
-publishdate:        "2012-07-31"
-draft:              false
+lastModified:       ~
 
 description:        "Responsive Web Design"
 
 thumbnail:          "images/posts/thumbnails/html5.jpg"
-header_img:         "images/posts/headers/elao_team_front.jpg"
+banner:             "images/posts/headers/elao_team_front.jpg"
 tags:               ["CSS", "Webdesign"]
 categories:         ["Dev", "Web", "CSS", "Webdesign"]
 

--- a/content/blog/dev/retour-experience-matomo.md
+++ b/content/blog/dev/retour-experience-matomo.md
@@ -2,14 +2,13 @@
 type:               "post"
 title:              "Sauvez un cookie 🍪, installez Matomo !"
 date:               "2019-03-21"
-publishdate:        "2019-03-21"
+lastModified:       ~
 tableOfContent:     2
-draft:              false
 
 description:        "Chez Elao, nous mesurons désormais l'audience de nos propres sites grâce à Matomo. Retour d'expérience. "
 
 thumbnail:          "images/posts/thumbnails/matomo.jpg"
-header_img:         "images/posts/headers/matomo.jpg"
+banner:             "images/posts/headers/matomo.jpg"
 tags:               ["Seo", "RGPD", "Matomo"]
 categories:         ["Dev", "Web"]
 

--- a/content/blog/dev/subdomains-symfony2-2-session-authentication.md
+++ b/content/blog/dev/subdomains-symfony2-2-session-authentication.md
@@ -2,14 +2,13 @@
 type:               "post"
 title:              "Feedback on a side-effect with Symfony 2.2, subdomains and sessions"
 date:               "2013-02-28"
-publishdate:        "2013-02-28"
+lastModified:       ~
 lang:               "en"
-draft:              false
 
 description:        "Feedback on a side-effect with Symfony 2.2, subdomains and sessions"
 
 thumbnail:          "images/posts/thumbnails/turtle.jpg"
-header_img:         "images/posts/headers/php_elao_code.jpg"
+banner:             "images/posts/headers/php_elao_code.jpg"
 tags:               ["Symfony", "PHP"]
 categories:         ["Dev", "Symfony", "PHP"]
 

--- a/content/blog/dev/symfony-2-doctrine-2-cheat-sheets.md
+++ b/content/blog/dev/symfony-2-doctrine-2-cheat-sheets.md
@@ -2,14 +2,13 @@
 type:               "post"
 title:              "Symfony 2 - Doctrine 2 - Cheat Sheets"
 date:               "2011-03-24"
-publishdate:        "2011-03-24"
+lastModified:       ~
 lang:               "en"
-draft:              false
 
 description:        "Symfony 2 - Doctrine 2 - Cheat Sheets"
 
 thumbnail:          "images/posts/thumbnails/cool_cat.jpg"
-header_img:         "images/posts/headers/elephpant_elao_family.jpg"
+banner:             "images/posts/headers/elephpant_elao_family.jpg"
 tags:               ["Symfony", "Doctrine", "Cheat sheets"]
 categories:         ["Dev", "Symfony", Doctrine]
 

--- a/content/blog/dev/symfony-2-linjection-de-dependances.md
+++ b/content/blog/dev/symfony-2-linjection-de-dependances.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Symfony 2 – L’injection de dépendances"
 date:               "2010-06-03"
-publishdate:        "2010-06-03"
-draft:              false
+lastModified:       ~
 
 description:        "Symfony 2 – L’injection de dépendances"
 

--- a/content/blog/dev/the-browserdetectorbundle-working-with-the-kernel-events.md
+++ b/content/blog/dev/the-browserdetectorbundle-working-with-the-kernel-events.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "The BrowserDetectorBundle: working with the Kernel events"
 date:               "2013-08-02"
-publishdate:        "2013-08-02"
-draft:              false
+lastModified:       ~
 
 description:        "The BrowserDetectorBundle: working with the Kernel events"
 

--- a/content/blog/dev/twig-quelques-pro-tips-issue-du-symfony-live-2013.md
+++ b/content/blog/dev/twig-quelques-pro-tips-issue-du-symfony-live-2013.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Twig : Quelques pro-tips issue du Symfony Live 2013"
 date:               "2013-04-19"
-publishdate:        "2013-04-19"
-draft:              false
+lastModified:       ~
 
 description:        "Twig : Quelques pro-tips issue du Symfony Live 2013"
 
 thumbnail:          "images/posts/thumbnails/badass_vader.jpg"
-header_img:         "images/posts/headers/php_forum_team_elao.jpg"
+banner:             "images/posts/headers/php_forum_team_elao.jpg"
 tags:               ["Tips", "Twig", "Symfony 2"]
 categories:         ["Tips", "Twig", "Symfony"]
 

--- a/content/blog/dev/two-ways-binding-avec-vue-et-vuex.md
+++ b/content/blog/dev/two-ways-binding-avec-vue-et-vuex.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Two Way-Binding avec Vue et Vuex"
 date:               "2019-09-25"
-publishdate:        "2019-09-25"
-draft:              false
+lastModified:       ~
 
 description:        "Mise en place d'un Two-Way Binding avec Vue et Vuex."
 
 thumbnail:          "images/posts/thumbnails/vuejs.jpg"
-header_img:         "images/posts/headers/vuejs.jpg"
+banner:             "images/posts/headers/vuejs.jpg"
 tags:               ["Vuejs","Javascript","Frontend","Framework"]
 categories:         ["Dev", "Vuejs", "Javascript", "Symfony"]
 

--- a/content/blog/dev/utilisation-de-levenement-kernel-terminate-sous-symfony2.md
+++ b/content/blog/dev/utilisation-de-levenement-kernel-terminate-sous-symfony2.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Utilisation de l'évènement kernel.terminate sous Symfony2"
 date:               "2013-07-18"
-publishdate:        "2013-07-18"
-draft:              false
+lastModified:       ~
 
 description:        "Utilisation de l'évènement kernel.terminate sous Symfony2"
 

--- a/content/blog/dev/webpack-encore-alias-namespace.md
+++ b/content/blog/dev/webpack-encore-alias-namespace.md
@@ -1,14 +1,13 @@
 ---
 type:               "post"
 title:              "Des namespaces en JavaScript ? C’est possible avec les alias Webpack Encore !"
-date:               "2020-07-30"
-publishdate:        "2020-07-31"
-draft:              false
+date:               "2020-07-31"
+lastModified:       ~
 
 description:        "Avec les alias Webpack Encore, adoptez la souplesse des namespaces PHP dans vos modules JavaScript avec des chemins absolus pour un code plus lisible et plus facile à refactorer."
 
 thumbnail:          "images/posts/thumbnails/webpack-encore-alias.jpg"
-header_img:         "images/posts/headers/webpack-encore-alias.jpg"
+banner:             "images/posts/headers/webpack-encore-alias.jpg"
 credits:            { name: "Jannes Glas" , url: "https://unsplash.com/@jannesglas" }
 
 tags:               ["Symfony", "JavaScript", "Webpack"]

--- a/content/blog/elao/afup-day-lyon-2019.md
+++ b/content/blog/elao/afup-day-lyon-2019.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "AFUP Day 2019 à Lyon : le compte-rendu de l'équipe"
 date:               "2019-05-20"
-publishdate:        "2019-05-20"
-draft:              false
+lastModified:       ~
 
 description:        "Notre compte-rendu de l'Afup Day à Lyon, du 17 mai 2019."
 
 thumbnail:          "images/posts/thumbnails/afup-day-2019.jpg"
-header_img:         "images/posts/headers/afup-day-2019.jpg"
+banner:             "images/posts/headers/afup-day-2019.jpg"
 tags:               ["Développement", "Web", "afup", "Conférence", "afupDay"]
 categories:         ["conference"]
 author:             ["tjarrand", "aldeboissieu", "mbernard", "bleveque", "dgauthier"]

--- a/content/blog/elao/best-of-web-2015.md
+++ b/content/blog/elao/best-of-web-2015.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Retour sur le Best Of Web 2015"
 date:               "2015-06-12"
-publishdate:        "2015-06-12"
-draft:              false
+lastModified:       ~
 
 description:        "La première édition du Best Of Web s'est tenue le Vendredi 5 Juin 2015 à Paris, et à rassembler le meilleurs des meetups de l'année. Retour sur cet évènement."
 
 thumbnail:          "images/posts/thumbnails/geek_evolution.jpg"
-header_img:         "images/posts/headers/forum_php_elao.jpg"
+banner:             "images/posts/headers/forum_php_elao.jpg"
 tags:               ["Javascript", "Web","conference"]
 categories:         ["Actualité", "Web", "conference"]
 

--- a/content/blog/elao/best-of-web-2016.md
+++ b/content/blog/elao/best-of-web-2016.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Retour sur le Best Of Web 2016"
 date:               "2016-06-17"
-publishdate:        "2016-06-17"
-draft:              false
+lastModified:       ~
 
 description:        "La seconde édition du Best Of Web s'est tenue le Vendredi 10 Juin 2016 à Paris, et a rassemblé le meilleur des meetups de l'année. Retour sur cet événement."
 
 thumbnail:          "images/posts/thumbnails/best-of-web-2016.jpg"
-header_img:         "images/posts/headers/best-of-web-2016.jpg"
+banner:             "images/posts/headers/best-of-web-2016.jpg"
 tags:               ["Javascript", "Web","conference"]
 categories:         ["Actualité", "Web", "conference"]
 

--- a/content/blog/elao/blendwebmix-2016.md
+++ b/content/blog/elao/blendwebmix-2016.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Blend Web Mix 2016 : un gros coup de boost"
 date:               "2016-11-08"
-publishdate:        "2016-11-08"
-draft:              false
+lastModified:       ~
 
 description:        ""
 
 thumbnail:          "images/posts/thumbnails/blend2016.jpg"
-header_img:         "images/posts/headers/blend2016.jpg"
+banner:             "images/posts/headers/blend2016.jpg"
 tags:               ["Web", "conférence", "blend", "lyon", "Développement", "Design", "Business"]
 categories:         ["Actualité", "Web", "conference"]
 

--- a/content/blog/elao/blendwebmix-2017.md
+++ b/content/blog/elao/blendwebmix-2017.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Le Blend Web Mix 2017 arrive !"
 date:               "2017-10-18"
-publishdate:        "2017-10-18"
-draft:              false
+lastModified:       ~
 
 description:        ""
 
 thumbnail:          "images/posts/thumbnails/pre-blend-2017.jpg"
-header_img:         "images/posts/headers/pre-blend-2017.jpg"
+banner:             "images/posts/headers/pre-blend-2017.jpg"
 tags:               ["Web", "conférence", "blend", "Lyon", "Développement", "Design", "Business"]
 categories:         ["Actualité", "Web", "conference"]
 

--- a/content/blog/elao/dotscale-paris-2017.md
+++ b/content/blog/elao/dotscale-paris-2017.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "DotScale Paris 2017"
 date:               "2017-04-24"
-publishdate:        "2017-04-24"
-draft:              false
+lastModified:       ~
 
 description:        "Aperçu du DotScale Paris 2017"
 
 thumbnail:          "images/posts/thumbnails/dotscale.jpg"
-header_img:         "images/posts/headers/dotscale.jpg"
+banner:             "images/posts/headers/dotscale.jpg"
 tags:               ["DevOps", "SysAdmin", "Infrastructure", "Conférence", "Scalabilité"]
 categories:         ["conference"]
 author:    "gfaivre"

--- a/content/blog/elao/elao-paris.md
+++ b/content/blog/elao/elao-paris.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "La tribu Elao Paris"
 date:               "2018-06-10"
-publishdate:        "2018-06-10"
-draft:              false
+lastModified:       ~
 
 description:        "Elao recherche des passionnés pour développer la tribu parisienne. A travers cette présentation d'Elao à Paris, nous espérons vous donner de bonnes raisons de nous rejoindre."
 
 thumbnail:          "images/posts/thumbnails/haphpybirthday.jpg"
-header_img:         "images/posts/headers/elephpant_elao_family.jpg"
+banner:             "images/posts/headers/elephpant_elao_family.jpg"
 tags:               ["Paris", "Recrutement", "Tribu",]
 categories:         ["elao", "methodo"]
 

--- a/content/blog/elao/forum-php-2015.md
+++ b/content/blog/elao/forum-php-2015.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Retour sur le Forum PHP 2015"
 date:               "2015-11-26"
-publishdate:        "2015-11-26"
-draft:              false
+lastModified:       ~
 
 description:        "Nous étions au Forum PHP de l'AFUP, voici ce que l'on a retenu."
 
 thumbnail:          "images/posts/thumbnails/haphpybirthday.jpg"
-header_img:         "images/posts/headers/elephpant_elao_family.jpg"
+banner:             "images/posts/headers/elephpant_elao_family.jpg"
 tags:               ["Conférence", "ForumPHP"]
 categories:         ["conference"]
 

--- a/content/blog/elao/forum-php-2016.md
+++ b/content/blog/elao/forum-php-2016.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Retour sur le Forum PHP 2016"
 date:               "2016-11-07"
-publishdate:        "2016-11-07"
-draft:              false
+lastModified:       ~
 
 description:        "Nous étions au Forum PHP 2016 de l'AFUP"
 
 thumbnail:          "images/posts/thumbnails/forumphp2016-thumb.jpg"
-header_img:         "images/posts/headers/forumphp2016.jpg"
+banner:             "images/posts/headers/forumphp2016.jpg"
 tags:               ["Développement", "Web", "afup", "Conférence", "ForumPHP"]
 categories:         ["conference"]
 author:             ["tjarrand", "bleveque", "lhoizey", "rchalas", "mcolin", "bviguier", "rhanna", "xgorse", "ndievart"]

--- a/content/blog/elao/forum-php-2018.md
+++ b/content/blog/elao/forum-php-2018.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Retour sur le Forum PHP 2018"
 date:               "2018-11-29"
-publishdate:        "2018-11-29"
-draft:              false
+lastModified:       ~
 
 description:        "En attendant l'AFUP Day, voici notre retour sur le Forum PHP 2018."
 
 thumbnail:          "images/posts/thumbnails/forumphp2018-team.jpeg"
-header_img:         "images/posts/headers/forumphp2018-team.jpeg"
+banner:             "images/posts/headers/forumphp2018-team.jpeg"
 tags:               ["Développement", "Web", "afup", "Conférence", "ForumPHP"]
 categories:         ["conference"]
 author:             ["rhanna", "tjarrand", "aldeboissieu", "ndievart"]

--- a/content/blog/elao/halloween-2019.md
+++ b/content/blog/elao/halloween-2019.md
@@ -2,14 +2,13 @@
 type:               "post"
 title:              "🎃 Films d'Halloween : la sélection de l'équipe 🍿"
 date:               "2019-10-31"
-publishdate:        "2019-10-31"
+lastModified:       ~
 tableOfContent:     2
-draft:              false
 
 description:        "Quelques idées pour rendre votre soirée d'Halloween un peu plus effrayante ou étrange ... 👻"
 
 thumbnail:          "images/posts/thumbnails/halloween-2019.jpg"
-header_img:         "images/posts/headers/halloween-2019.jpg"
+banner:             "images/posts/headers/halloween-2019.jpg"
 tags:               ["Halloween", "cinema"]
 categories:         ["elao"]
 

--- a/content/blog/elao/hs-bien-preparer-sa-conference.md
+++ b/content/blog/elao/hs-bien-preparer-sa-conference.md
@@ -3,8 +3,7 @@
 type:               "post"
 title:              "Comment bien préparer sa conférence ?"
 date:               "2014-06-03"
-publishdate:        "2014-06-03"
-draft:              false
+lastModified:       ~
 
 description:        "Comment bien préparer sa conférence ?"
 

--- a/content/blog/elao/le-teletravail-point-de-vue.md
+++ b/content/blog/elao/le-teletravail-point-de-vue.md
@@ -1,14 +1,13 @@
 ---
 type:               "post"
 title:              "Le télétravail, point de vue"
-date:               "2015-08-14"
-publishdate:        "2015-09-08"
-draft:              false
+date:               "2015-09-08"
+lastModified:       ~
 
 description:        "Pratique encore relativement marginale dans l'entreprise française, le télétravail s'imposera sans doute dans les années à venir comme une réelle alternative aux méthodes traditionnelles. Bilan sur ses avantages et ses inconvénients, de mon point de vue."
 
 thumbnail:          "images/posts/thumbnails/RemoteMountain.jpg"
-header_img:         "images/posts/headers/elao_babyfoot.jpg"
+banner:             "images/posts/headers/elao_babyfoot.jpg"
 tags:               ["teletravail", "vie au travail"]
 categories:         ["vie au bureau", "elao"]
 

--- a/content/blog/elao/mix-it-2015-pt1.md
+++ b/content/blog/elao/mix-it-2015-pt1.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Retour sur le Mix-IT 2015 (Lyon)"
 date:               "2015-04-20"
-publishdate:        "2015-04-20"
-draft:              false
+lastModified:       ~
 
 description:        "L'édition 2015 du Mix-IT s'est tenue les 16 et 17 avril au CPE de Lyon. Retour sur cet événement."
 
 thumbnail:          "images/posts/thumbnails/unepetitemousse-mixit.jpg"
-header_img:         "images/posts/headers/elephpant_elao_family.jpg"
+banner:             "images/posts/headers/elephpant_elao_family.jpg"
 tags:               ["Conférence", "Mix-IT 2015"]
 categories:         ["Dev", "Web", "conference", "Javascript", "NodeJS"]
 

--- a/content/blog/elao/mixit-2018.md
+++ b/content/blog/elao/mixit-2018.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Retour sur le MiXiT 2018"
 date:               "2018-05-16"
-publishdate:        "2018-05-16"
-draft:              false
+lastModified:       ~
 
 description:        "Nos retours sur les conférences du MiXiT 2018."
 
 thumbnail:          "images/posts/thumbnails/mixit-2018.png"
-header_img:         "images/posts/headers/mixit-2018.jpg"
+banner:             "images/posts/headers/mixit-2018.jpg"
 tags:               ["Javascript", "Web","Conférence"]
 categories:         ["Dev", "Actualité", "Web", "Conférence"]
 

--- a/content/blog/elao/ncrafts-2016.md
+++ b/content/blog/elao/ncrafts-2016.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Retour sur la nCrafts 2016"
 date:               "2016-05-17"
-publishdate:        "2016-05-17"
-draft:              false
+lastModified:       ~
 
 description:        "Les 12 et 13 mai se déroulait à Paris la nCrafts, une conférence indépendante et internationale sur le développement logiciel."
 
 thumbnail:          "images/posts/thumbnails/ncrafts-2016.jpg"
-header_img:         "images/posts/headers/ncrafts-2016.jpg"
+banner:             "images/posts/headers/ncrafts-2016.jpg"
 tags:               ["Développement", "Web","conference", "nCrafts", "craftsmanship"]
 categories:         ["Actualité", "Web", "conference"]
 

--- a/content/blog/elao/nodeschool-paris.md
+++ b/content/blog/elao/nodeschool-paris.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Retour sur la NodeSchool Paris"
 date:               "2015-05-27"
-publishdate:        "2015-05-27"
-draft:              false
+lastModified:       ~
 
 description:        "La NodeSchool permet de pratiquer Javascript et Node.js grâce à des ateliers interactifs."
 
 thumbnail:          "images/posts/thumbnails/nodejs.png"
-header_img:         "images/posts/headers/php_elao_code.jpg"
+banner:             "images/posts/headers/php_elao_code.jpg"
 tags:               ["Javascript", "Node.js", "Conférences"]
 categories:         ["Dev", "conference", "Javascript", "NodeJS"]
 

--- a/content/blog/elao/nuit-du-hack-XV.md
+++ b/content/blog/elao/nuit-du-hack-XV.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Nuit du Hack XV"
 date:               "2017-06-29"
-publishdate:        "2017-06-29"
-draft:              false
+lastModified:       ~
 
 description:        "La quinzième édition de la Nuit Du Hack (#NDHXV) s'est tenue le Samedi 24 Juin 2017 en région parisienne."
 
 thumbnail:          "images/posts/thumbnails/ndhxv.png"
-header_img:         "images/posts/headers/ndhxv.jpg"
+banner:             "images/posts/headers/ndhxv.jpg"
 tags:               ["SysAdmin", "Sécurité", "Conférence", "Hacking"]
 categories:         ["conference"]
 author:    "gfaivre"

--- a/content/blog/elao/phptour-2016.md
+++ b/content/blog/elao/phptour-2016.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "PHP Tour 2016, Merciiiiii"
 date:               "2016-05-27"
-publishdate:        "2016-05-27"
-draft:              false
+lastModified:       ~
 
 description:        "Les 23 et 24 mai se déroulait à Clermont-Ferrand le PHP Tour 2016. Pour l'occasion l'Afup et Clermont'ech ont à nouveau réuni la communauté open source PHP."
 
 thumbnail:          "images/posts/thumbnails/phptour-thumbnail.jpg"
-header_img:         "images/posts/headers/phptour-2016.jpg"
+banner:             "images/posts/headers/phptour-2016.jpg"
 tags:               ["Développement", "Web", "conférence", "afup", "clermont'ech"]
 categories:         ["Actualité", "Web", "conference"]
 

--- a/content/blog/elao/rebranding-la-forme.md
+++ b/content/blog/elao/rebranding-la-forme.md
@@ -3,7 +3,7 @@
 type:               "post"
 title:              "Rebranding 2/4 : la forme"
 date:               "2021-04-27"
-publishdate:        "2021-04-27"
+lastModified:       ~
 tableOfContent:     true
 
 description:        "Après le fond, la forme."

--- a/content/blog/elao/rebranding-la-tech.md
+++ b/content/blog/elao/rebranding-la-tech.md
@@ -3,7 +3,7 @@
 type:               "post"
 title:              "Rebranding 3/4 : la tech"
 date:               "2021-05-04"
-publishdate:        "2021-05-04"
+lastModified:       ~
 tableOfContent:     2
 
 description:        "On s'outille."

--- a/content/blog/elao/rebranding-le-fond.md
+++ b/content/blog/elao/rebranding-le-fond.md
@@ -3,14 +3,12 @@
 type:               "post"
 title:              "Rebranding 1/4 : le fond"
 date:               "2021-04-20"
-publishdate:        "2021-04-20"
-draft:              false
+lastModified:       ~
 tableOfContent:     2
 
 description:        "On pose les bases."
 
 thumbnail:          "images/posts/headers/elao-rebrand-banner-fond.jpg"
-header_img:         "images/posts/headers/elao-rebrand-banner-fond.jpg"
 tags:               ["Rebranding", "Elao"]
 categories:         ["Elao"]
 authors:            ["xgorse","cmozzati"]

--- a/content/blog/elao/retour-paris-web.md
+++ b/content/blog/elao/retour-paris-web.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Retour sur Paris Web 2015"
 date:               "2015-10-14"
-publishdate:        "2015-10-14"
-draft:              false
+lastModified:       ~
 
 description:        "Paris Web, la conférence francophone des gens qui font le web !"
 
 thumbnail:          "images/posts/thumbnails/unicorn.jpg"
-header_img:         "images/posts/headers/unicorn.jpg"
+banner:             "images/posts/headers/unicorn.jpg"
 tags:               ["ParisWeb", "Conférences"]
 categories:         ["conference"]
 

--- a/content/blog/elao/symfony-live-2015.md
+++ b/content/blog/elao/symfony-live-2015.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Retour sur le Symfony Live 2015"
 date:               "2015-04-10"
-publishdate:        "2015-04-10"
-draft:              false
+lastModified:       ~
 
 description:        "La septième édition du SymfonyLive Paris s'est tenue le jeudi 9 avril à la Cité Internationale Universitaire de Paris. Retour sur cet évènement."
 
 thumbnail:          "images/posts/thumbnails/SymfonyLive.png"
-header_img:         "images/posts/headers/php_forum_team_elao_2.jpg"
+banner:             "images/posts/headers/php_forum_team_elao_2.jpg"
 tags:               ["Conférence", "Symfony Live", "Conférence"]
 categories:         ["conference", "Symfony Live"]
 

--- a/content/blog/elao/symfonycon-2015.md
+++ b/content/blog/elao/symfonycon-2015.md
@@ -1,14 +1,13 @@
 ---
 type:               "post"
 title:              "Retour sur la SymfonyCon 2015"
-date:               "2015-12-04"
-publishdate:        "2015-12-17"
-draft:              false
+date:               "2015-12-17"
+lastModified:       ~
 
 description:        "Nous étions à la SymfonyCon 2015 pour fêter les 10 ans de Symfony"
 
 thumbnail:          "images/posts/thumbnails/symfonycon-2015.jpg"
-header_img:         "images/posts/headers/foliesbergeres.jpg"
+banner:             "images/posts/headers/foliesbergeres.jpg"
 tags:               ["Conférence", "Symfony", "SymfonyCon"]
 categories:         ["conference"]
 

--- a/content/blog/infra/acceder-api-cross-domain-depuis-javascript-avec-cors-reverse-proxy-nginx.md
+++ b/content/blog/infra/acceder-api-cross-domain-depuis-javascript-avec-cors-reverse-proxy-nginx.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Accéder à une API cross-domain depuis Javascript avec CORS et un reverse proxy nginx"
 date:               "2016-11-03"
-publishdate:        "2016-11-03"
-draft:              false
+lastModified:       ~
 
 description:        "Configurer un reverse proxy avec nginx et CORS pour permettre à une application Javascript d'accéder à une API sur un autre domaine en contournant la Same Origin Policy."
 
 thumbnail:          "images/posts/thumbnails/bridge.jpg"
-header_img:         "images/posts/headers/bridge.jpg"
+banner:             "images/posts/headers/bridge.jpg"
 tags:               ["Nginx", "Reverse", "Proxy", "Cors"]
 categories:         ["Infra", "nginx", "javascript"]
 

--- a/content/blog/infra/authentification-http-avec-haproxy.md
+++ b/content/blog/infra/authentification-http-avec-haproxy.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Authentification HTTP avec HA Proxy"
 date:               "2015-03-10"
-publishdate:        "2015-03-10"
-draft:              false
+lastModified:       ~
 
 description:        "Comment gérer une authentification HTTP basique avec HA Proxy, définir des utilisateurs, des groupes et le type d'authentification souhaitée."
 

--- a/content/blog/infra/authentifications-multiples-a-partir-de-cles-ssh.md
+++ b/content/blog/infra/authentifications-multiples-a-partir-de-cles-ssh.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Authentifications multiples à partir de clés SSH"
 date:               "2010-04-11"
-publishdate:        "2010-04-11"
-draft:              false
+lastModified:       ~
 
 description:        "Authentifications multiples à partir de clés SSH."
 

--- a/content/blog/infra/comprendre-lheritage-des-instructions-de-configuration-de-nginx.md
+++ b/content/blog/infra/comprendre-lheritage-des-instructions-de-configuration-de-nginx.md
@@ -1,14 +1,13 @@
 ---
 type:           "post"
 title:          "Comprendre l'héritage des instructions de configuration de Nginx"
-date:           "2015-11-30"
-publishdate:    "2016-01-11"
-draft:          false
+date:           "2016-01-11"
+lastModified:       ~
 
 description:    "Nginx fonctionne avec une notion de contexte autorisant certaines instructions de configuration. Nous évoquons dans cet article comment Nginx traite et organise ces différents blocs."
 
 thumbnail:      "images/posts/thumbnails/geek_love.jpg"
-header_img:     "images/posts/headers/stickers.jpg"
+banner:     "images/posts/headers/stickers.jpg"
 tags:           ["infra", "nginx", "linux"]
 categories:     ["infra", "nginx"]
 

--- a/content/blog/infra/creer-un-cluster-2-nodes-proxmox.md
+++ b/content/blog/infra/creer-un-cluster-2-nodes-proxmox.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Créer un cluster 2 nodes Proxmox"
 date:               "2015-01-16"
-publishdate:        "2015-01-16"
-draft:              false
+lastModified:       ~
 
 description:        "Rapide présentation d'une fonctionnalité intéressante des distributions Proxmox qui permet de faire du clustering avec deux ou plusieures machines physiques."
 

--- a/content/blog/infra/creer-une-autorite-de-certification-et-des-certificats-ssl-auto-signes.md
+++ b/content/blog/infra/creer-une-autorite-de-certification-et-des-certificats-ssl-auto-signes.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Créer une autorité de certification et des certificats SSL auto-signés"
 date:               "2010-10-05"
-publishdate:        "2010-10-05"
-draft:              false
+lastModified:       ~
 
 description:        "Créer une autorité de certification et des certificats SSL auto-signés"
 

--- a/content/blog/infra/feedback-monitor-your-symfony2-application-via-stats-d-and-graphite.md
+++ b/content/blog/infra/feedback-monitor-your-symfony2-application-via-stats-d-and-graphite.md
@@ -2,9 +2,8 @@
 type:               "post"
 title:              "Feedback : Monitor your Symfony2 application via Stats.d and Graphite"
 date:               "2013-07-18"
-publishdate:        "2013-07-18"
+lastModified:       ~
 lang:               "en"
-draft:              false
 
 description:        "Feedback : Monitor your Symfony2 application via Stats.d and Graphite"
 

--- a/content/blog/infra/install-stats-d-graphite-on-a-debian-server-to-monitor-a-symfony2-application.md
+++ b/content/blog/infra/install-stats-d-graphite-on-a-debian-server-to-monitor-a-symfony2-application.md
@@ -2,15 +2,14 @@
 type:               "post"
 title:              "Install Stats.d / Graphite on a debian server in order to monitor a Symfony2 application (1/2)"
 date:               "2012-11-23"
-publishdate:        "2012-11-23"
+lastModified:       ~
 lang:               "en"
-draft:              false
 
 description:        "Install Stats.d / Graphite on a debian server in order to monitor a Symfony2 application."
 
 language:           "en"
 thumbnail:          "images/posts/thumbnails/rocket.jpg"
-header_img:         "images/posts/headers/minions.jpg"
+banner:             "images/posts/headers/minions.jpg"
 tags:               ["Linux","Monitoring","Symfony"]
 categories:         ["Infra", "Monitoring"]
 

--- a/content/blog/infra/installation-d-un-depot-svn.md
+++ b/content/blog/infra/installation-d-un-depot-svn.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Installation d'un dépôt SVN"
 date:               "2009-12-02"
-publishdate:        "2009-12-02"
-draft:              false
+lastModified:       ~
 
 description:        "Installation d'un dépôt SVN pour gérer et versioner le code source d'un projet"
 

--- a/content/blog/infra/installation-de-fuse-et-s3fs-sur-une-debian-lenny.md
+++ b/content/blog/infra/installation-de-fuse-et-s3fs-sur-une-debian-lenny.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Installation de FUSE et s3fs sur une Debian Lenny"
 date:               "2010-01-12"
-publishdate:        "2010-01-12"
-draft:              false
+lastModified:       ~
 
 description:        "Installation de FUSE et s3fs sur une Debian Lenny"
 

--- a/content/blog/infra/installer-graphite-sur-debian-wheezy.md
+++ b/content/blog/infra/installer-graphite-sur-debian-wheezy.md
@@ -3,8 +3,7 @@
 type:               "post"
 title:              "Installer graphite sur Debian Wheezy"
 date:               "2014-12-20"
-publishdate:        "2014-12-20"
-draft:              false
+lastModified:       ~
 
 description:        "Installation de graphite avec Gunicorn et Nginx sur debian Wheezy."
 

--- a/content/blog/infra/introduction-a-vagrant.md
+++ b/content/blog/infra/introduction-a-vagrant.md
@@ -1,14 +1,13 @@
 ---
 type:               "post"
 title:              "Introduction à Vagrant"
-date:               "2017-04-24"
-publishdate:        "2017-04-23"
-draft:              false
+date:               "2017-04-23"
+lastModified:       ~
 
 description:        "Le fonctionnement et les principes utilisés par Vagrant. Comment installer une VM contenant une version minimale d'Ubuntu et la provisionner avec nginx."
 
 thumbnail:          "images/posts/thumbnails/vagrant.png"
-header_img:         "images/posts/headers/vagrant.png"
+banner:             "images/posts/headers/vagrant.png"
 tags:               ["Vagrant", "Virtualisation"]
 categories:         ["Infra", "Virtualisation", "Vagrant"]
 

--- a/content/blog/infra/introduction-au-provisioning.md
+++ b/content/blog/infra/introduction-au-provisioning.md
@@ -1,14 +1,13 @@
 ---
 type:               "post"
 title:              "Introduction au provisioning"
-date:               "2015-12-09"
-publishdate:        "2016-02-03"
-draft:              false
+date:               "2016-02-03"
+lastModified:       ~
 
 description:        "Introduction aux principes de base de l'approvisionnement (ou provisoning) d'environnements de développement, d'exécution, de production ou encore de test"
 
 thumbnail:          "images/posts/thumbnails/puppet.jpg"
-header_img:         "images/posts/headers/php_elao_code.jpg"
+banner:             "images/posts/headers/php_elao_code.jpg"
 tags:               ["Ansible", "Linux", "Virtualisation"]
 categories:         ["Infra", "Virtualisation", "Provisioning", "Ansible"]
 

--- a/content/blog/infra/migrer-un-site-web-sans-interruption-de-service-grace-au-reverse-proxy-dapache.md
+++ b/content/blog/infra/migrer-un-site-web-sans-interruption-de-service-grace-au-reverse-proxy-dapache.md
@@ -3,13 +3,12 @@
 type:               "post"
 title:              "Migrer un site web sans interruption de service grâce au reverse proxy d'Apache."
 date:               "2012-05-04"
-publishdate:        "2012-05-04"
-draft:              false
+lastModified:       ~
 
 description:        "Migrer un site web sans interruption de service grâce au reverse proxy d'Apache."
 
 thumbnail:          "images/posts/thumbnails/pulp_starwars.png"
-header_img:         "images/posts/headers/php_elao_code.jpg"
+banner:             "images/posts/headers/php_elao_code.jpg"
 tags:               ["Apache","Linux","Trucs et astuces"]
 categories:         ["Infra", "Linux"]
 

--- a/content/blog/infra/monitor-your-symfony2-application-via-stats-d-and-graphite-2.md
+++ b/content/blog/infra/monitor-your-symfony2-application-via-stats-d-and-graphite-2.md
@@ -2,14 +2,13 @@
 type:               "post"
 title:              "Monitor your Symfony2 application via Stats.d and Graphite (2/2)"
 date:               "2012-11-23"
-publishdate:        "2012-11-23"
+lastModified:       ~
 lang:               "en"
-draft:              false
 
 description:        "Monitor your Symfony2 application via Stats.d and Graphite Part. 2"
 
 thumbnail:          "images/posts/thumbnails/rocket.jpg"
-header_img:         "images/posts/headers/minions.jpg"
+banner:             "images/posts/headers/minions.jpg"
 tags:               ["Monitoring", "symfony", "Statd", "infra", "ops"]
 categories:         ["Infra", "Monitoring"]
 

--- a/content/blog/infra/operation-sur-un-fichier-avec-la-commande-find.md
+++ b/content/blog/infra/operation-sur-un-fichier-avec-la-commande-find.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Opération sur un fichier avec la commande find"
 date:               "2009-12-03"
-publishdate:        "2009-12-03"
-draft:              false
+lastModified:       ~
 
 description:        "Opération sur un fichier avec la commande find"
 

--- a/content/blog/infra/partitionnement-d-un-serveur-proxmox.md
+++ b/content/blog/infra/partitionnement-d-un-serveur-proxmox.md
@@ -3,8 +3,7 @@
 type:               "post"
 title:              "Partitionnement d'un serveur proxmox"
 date:               "2014-11-06"
-publishdate:        "2014-11-06"
-draft:              false
+lastModified:       ~
 
 description:        "Petit billet mémo aujourd'hui concernant le partitionnement d'un serveur Proxmox, rien de bien sorcier en soi mais il est toujours bon d'avoir un référentiel auquel se fier."
 

--- a/content/blog/infra/provisonner-simplement-stack-monitoring-telegraf-influxdb-grafana-avec-manala.md
+++ b/content/blog/infra/provisonner-simplement-stack-monitoring-telegraf-influxdb-grafana-avec-manala.md
@@ -2,14 +2,13 @@
 type:               "post"
 title:              "Provisionner simplement une stack de monitoring Telegraf + InfluxDB + Grafana avec Manala"
 date:               "2017-01-25"
-publishdate:        "2017-01-25"
-draft:              false
+lastModified:       ~
 
 description:        "Comment utiliser les roles Ansible de Manala pour provisionner simplement une stack de monitoring Telegraf + InfluxDB + Grafana"
 
 language:           "fr"
 thumbnail:          "images/posts/thumbnails/grafana.jpg"
-header_img:         "images/posts/headers/grafana.jpg"
+banner:             "images/posts/headers/grafana.jpg"
 tags:               ["provisoning","manala","ansible","influxdb","grafana","telegraf","monitoring"]
 categories:         ["Infra", "manala", "ansible"]
 

--- a/content/blog/infra/securiser-ses-acces-serveur-authentification-par-cles-ssh.md
+++ b/content/blog/infra/securiser-ses-acces-serveur-authentification-par-cles-ssh.md
@@ -3,8 +3,7 @@
 type:               "post"
 title:              "Sécuriser ses accès serveur: Authentification par clés SSH"
 date:               "2010-03-05"
-publishdate:        "2010-03-05"
-draft:              false
+lastModified:       ~
 
 description:        "Sécuriser ses accès serveur: Authentification par clés SSH."
 

--- a/content/blog/infra/ssl-generer-une-demande-de-signature-de-certificat-csr.md
+++ b/content/blog/infra/ssl-generer-une-demande-de-signature-de-certificat-csr.md
@@ -3,13 +3,12 @@
 type:               "post"
 title:              "SSL - Générer une demande de signature de certificat"
 date:               "2015-03-13"
-publishdate:        "2015-03-13"
-draft:              false
+lastModified:       ~
 
 description:        "Comment générer une demande de signature d'un certificat SSL (CSR) à destination d'une autorité de certification."
 
 thumbnail:          "images/posts/thumbnails/crypto.jpg"
-header_img:         "images/posts/headers/elao_babyfoot.jpg"
+banner:             "images/posts/headers/elao_babyfoot.jpg"
 tags:               ["Infra", "Linux", "SSL", "Certicats", "Sécurité"]
 categories:         ["Infra", "Sécurité", "Linux"]
 

--- a/content/blog/infra/syntaxe-des-enregistrements-spf-sender-privacy-framework.md
+++ b/content/blog/infra/syntaxe-des-enregistrements-spf-sender-privacy-framework.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Syntaxe des enregistrements SPF (Sender Privacy Framework)"
 date:               "2009-12-05"
-publishdate:        "2009-12-05"
-draft:              false
+lastModified:       ~
 
 description:        "Syntaxe des enregistrements SPF, cas d'utilisation et options de configuration."
 

--- a/content/blog/infra/utilisation-de-la-commande-find-cas-pratiques.md
+++ b/content/blog/infra/utilisation-de-la-commande-find-cas-pratiques.md
@@ -2,8 +2,7 @@
 type:               "post"
 title:              "Utilisation de la commande find - cas pratiques"
 date:               "2010-04-23"
-publishdate:        "2010-04-23"
-draft:              false
+lastModified:       ~
 
 description:        "Utilisation de la commande find - cas pratiques"
 

--- a/content/blog/infra/utiliser-l-api-openstack-ovh.md
+++ b/content/blog/infra/utiliser-l-api-openstack-ovh.md
@@ -2,13 +2,12 @@
 type:               "post"
 title:              "Utiliser l'API Openstack OVH"
 date:               "2016-12-16"
-publishdate:        "2016-12-16"
-draft:              false
+lastModified:       ~
 
 description:        "Préparer son environnement pour utiliser l'API openstack d'OVH, pré-requis et installation du client"
 
 thumbnail:          "images/posts/thumbnails/openstack.png"
-header_img:         "images/posts/headers/facade.jpg"
+banner:             "images/posts/headers/facade.jpg"
 tags:               ["ovh","openstack","docker","infra","api"]
 categories:         ["Infra", "openstack", "ovh"]
 

--- a/content/blog/infra/utiliser-les-depots-officiels-nginx-sur-debian-wheezy.md
+++ b/content/blog/infra/utiliser-les-depots-officiels-nginx-sur-debian-wheezy.md
@@ -3,8 +3,7 @@
 type:               "post"
 title:              "Utiliser les dépôts officiels Nginx sur Debian Wheezy"
 date:               "2014-12-19"
-publishdate:        "2014-12-19"
-draft:              false
+lastModified:       ~
 
 description:        "Comment configurer et utiliser les dépôts Nginx sur Debian Wheezy."
 

--- a/content/blog/infra/utiliser-supervisor-pour-controler-ses-services-applicatifs.md
+++ b/content/blog/infra/utiliser-supervisor-pour-controler-ses-services-applicatifs.md
@@ -3,8 +3,7 @@
 type:               "post"
 title:              "Controller ses services applicatifs avec supervisor"
 date:               "2014-12-22"
-publishdate:        "2014-12-22"
-draft:              false
+lastModified:       ~
 
 description:        "Supervisor est un système de contrôle des processus/services applicatifs destiné aux systèmes de types UNIX."
 

--- a/content/blog/methodo/gestion-projet-agile-github.md
+++ b/content/blog/methodo/gestion-projet-agile-github.md
@@ -1,14 +1,13 @@
 ---
 type:           "post"
 title:          "Gérer un projet AGILE avec GitHub"
-date:           "2017-04-24"
-publishdate:    "2017-04-26"
-draft:          false
+date:           "2017-04-26"
+lastModified:       ~
 
 description:    "Retour d'expérience sur la gestion d'un projet avec GitHub."
 
 thumbnail:      "images/posts/thumbnails/github-agile.jpg"
-header_img:     "images/posts/headers/github-agile.jpg"
+banner:     "images/posts/headers/github-agile.jpg"
 tags:           ["agile", "scrum", "kanban", "gestion de projet", "github"]
 categories:     ["methodo"]
 

--- a/content/blog/methodo/github-agile-dashboard.md
+++ b/content/blog/methodo/github-agile-dashboard.md
@@ -1,14 +1,13 @@
 ---
 type:           "post"
 title:          "GAD : Github Agile Dashboard"
-date:           "2017-06-28"
-publishdate:    "2017-07-04"
-draft:          false
+date:           "2017-07-04"
+lastModified:       ~
 
 description:    "Comment j'ai créé un petit outil en ligne de commande pour m'aider dans mon quotidien agile"
 
 thumbnail:      "images/posts/thumbnails/github-agile-dashboard.jpg"
-header_img:     "images/posts/headers/github-agile-dashboard.jpg"
+banner:     "images/posts/headers/github-agile-dashboard.jpg"
 tags:           ["agile", "scrum", "kanban", "gestion de projet", "github", "git", "node", "cli"]
 categories:     ["methodo", "dev"]
 

--- a/content/blog/methodo/notre-quotidien-equipe-projet-auto-organisee.md
+++ b/content/blog/methodo/notre-quotidien-equipe-projet-auto-organisee.md
@@ -2,13 +2,12 @@
 type:           "post"
 title:          "Notre quotidien d'équipe projet auto-organisée"
 date:           "2016-12-01"
-publishdate:    "2016-12-01"
-draft:          false
+lastModified:       ~
 
 description:    "Retour d'expérience sur la vie d'une équipe projet auto-organisée. Voici ce que nous avons mis en place progressivement, nos expérimentations, nos succès et nos échecs."
 
 thumbnail:      "images/posts/thumbnails/equipe_projet.jpg"
-header_img:     "images/posts/2016/equipe-projet/equipe.jpg"
+banner:     "images/posts/2016/equipe-projet/equipe.jpg"
 tags:           ["agile", "user stories"]
 categories:     ["methodo"]
 

--- a/content/blog/methodo/specifions-user-stories.md
+++ b/content/blog/methodo/specifions-user-stories.md
@@ -1,14 +1,13 @@
 ---
 type:           "post"
 title:          "Spécifions les user stories"
-date:           "2015-11-30"
-publishdate:    "2015-12-07"
-draft:          false
+date:           "2015-12-07"
+lastModified:       ~
 
 description:    "L'écriture d'user stories n'est pas aussi simple qu'elle peut le paraître. Avec un minimum de guide, on peut s'améliorer rapidement."
 
 thumbnail:      "images/posts/thumbnails/50-quick.jpg"
-header_img:     "images/posts/headers/elao_team_front.jpg"
+banner:     "images/posts/headers/elao_team_front.jpg"
 tags:           ["agile", "user stories", "specifications"]
 categories:     ["methodo"]
 

--- a/content/blog/styleguide/example.md
+++ b/content/blog/styleguide/example.md
@@ -2,13 +2,14 @@
 type:               "post"
 title:              "Petit guide de style du blog"
 date:               "2020-09-23"
-publishdate:        "2020-09-23"
-draft:              true
+#lastModified:       ~ # A utiliser par défaut
+lastModified:       "2021-03-17" # A utiliser pour indiquer explicitement qu'un article a été mis à jour
 tableOfContent:     3
 
 description:        "Tour d'horizon de ce qu'on a pour faire de beaux articles. Et quelques bonnes pratiques de rédaction."
 
 thumbnail:          https://images.unsplash.com/photo-1533142266415-ac591a4deae9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60
+banner:             ~ # Si vous voulez une image différente des miniatures comme bannière sur la vue de l'article
 credits:            { name: "Jon Tyson", url: "https://unsplash.com/@jontyson" }
 tags:               ["Tag 1", "Tag 2"]
 categories:         ["Dev", "Symfony"]

--- a/content/blog/tech/configuration-de-bind-sous-mac-os-x.md
+++ b/content/blog/tech/configuration-de-bind-sous-mac-os-x.md
@@ -3,8 +3,7 @@
 type:               "post"
 title:              "Configuration de Bind sous Mac OS X"
 date:               "2010-05-21"
-publishdate:        "2010-05-21"
-draft:              false
+lastModified:       ~
 
 description:        "Configuration de Bind sous Mac OS X."
 

--- a/content/blog/tech/creer-une-cle-bootable-osx-10-10-yosemite.md
+++ b/content/blog/tech/creer-une-cle-bootable-osx-10-10-yosemite.md
@@ -3,8 +3,7 @@
 type:               "post"
 title:              "Créer une clé bootable OSX 10.10 Yosemite"
 date:               "2014-09-17"
-publishdate:        "2014-09-17"
-draft:              false
+lastModified:       ~
 
 description:        "Créer une clé bootable OSX 10.10 Yosemite."
 

--- a/content/blog/tech/ssh-agent-does-not-automatically-load-passphrases-on-the-osx-sierra-keychain.md
+++ b/content/blog/tech/ssh-agent-does-not-automatically-load-passphrases-on-the-osx-sierra-keychain.md
@@ -2,14 +2,13 @@
 type:               "post"
 title:              "SSH-agent does not automatically load passphrases on the OSX Sierra keychain during startup"
 date:               "2016-10-14"
-publishdate:        "2016-10-14"
-draft:              false
+lastModified:       ~
 lang:               "en"
 
 description:        "SSH-agent does not automatically load passphrases on the OSX Sierra keychain during startup."
 
 thumbnail:          "images/posts/thumbnails/badass_vader.jpg"
-header_img:         "images/posts/headers/php_elao_code.jpg"
+banner:             "images/posts/headers/php_elao_code.jpg"
 tags:               ["SSH", "OSX"]
 categories:         ["Dev", "Tech", "OSX"]
 

--- a/content/job/job-adminsys-agence-lyon-2018.md
+++ b/content/job/job-adminsys-agence-lyon-2018.md
@@ -1,7 +1,6 @@
 ---
 type:           "post"
 title:          "À la recherche d'un(e) «Sysadmin»"
-date:           "2018-05-29"
 publishdate:    "2018-05-29"
 draft:          false
 

--- a/content/job/job-developpeur-backend-agence-lyon-2018.md
+++ b/content/job/job-developpeur-backend-agence-lyon-2018.md
@@ -1,7 +1,6 @@
 ---
 type:           "post"
 title:          "À la recherche d'un développeur ou d'une développeuse Back"
-date:           "2018-02-14"
 publishdate:    "2018-02-27"
 draft:          false
 

--- a/content/job/job-developpeur-backend-agence-paris-2018.md
+++ b/content/job/job-developpeur-backend-agence-paris-2018.md
@@ -1,7 +1,6 @@
 ---
 type:           "post"
 title:          "À la recherche de développeurs.euses Back"
-date:           "2018-06-11"
 publishdate:    "2018-06-11"
 draft:          false
 

--- a/content/job/job-developpeur-backend-lyon-2019.md
+++ b/content/job/job-developpeur-backend-lyon-2019.md
@@ -1,7 +1,6 @@
 ---
 type:           "post"
 title:          "À la recherche d'une développeuse / un développeur Backend"
-date:           "2019-11-12"
 publishdate:    "2019-11-12"
 draft:          false
 active:         true

--- a/content/job/job-facilitateur-agence-lyon-2018.md
+++ b/content/job/job-facilitateur-agence-lyon-2018.md
@@ -1,7 +1,6 @@
 ---
 type:           "post"
 title:          "Facilitateur(trice) projet, j'ai besoin d'aide."
-date:           "2018-02-14"
 publishdate:    "2018-02-26"
 draft:          false
 

--- a/content/job/job-frontend-developpeur-agence-lyon-2018.md
+++ b/content/job/job-frontend-developpeur-agence-lyon-2018.md
@@ -1,7 +1,6 @@
 ---
 type:           "post"
 title:          "A la recherche d'un développeur ou d'une développeuse Frontend pour notre agence de Lyon"
-date:           "2018-02-14"
 publishdate:    "2018-02-27"
 draft:          false
 

--- a/content/job/jobs-agence-lyon-2018.md
+++ b/content/job/jobs-agence-lyon-2018.md
@@ -1,7 +1,6 @@
 ---
 type:           "post"
 title:          "Session recrutements chez élao !"
-date:           "2018-02-19"
 publishdate:    "2018-02-28"
 draft:          false
 active:         true

--- a/content/job/nous-recherchons-notre-integrateur-web-a-lyon.md
+++ b/content/job/nous-recherchons-notre-integrateur-web-a-lyon.md
@@ -1,7 +1,6 @@
 ---
 type:           "post"
 title:          "Intégrer... notre agence de Lyon"
-date:           "2017-01-20"
 publishdate:    "2017-01-20"
 draft:          false
 

--- a/content/job/stagiaire-elao.md
+++ b/content/job/stagiaire-elao.md
@@ -1,7 +1,6 @@
 ---
 type:               "post"
 title:              "Retour d'expérience d'un stagiaire Elao"
-date:               "2017-05-29"
 publishdate:        "2017-06-19"
 draft:              false
 

--- a/src/Controller/BlogController.php
+++ b/src/Controller/BlogController.php
@@ -37,7 +37,7 @@ class BlogController extends AbstractController
             'page' => $page,
             'minPage' => 1,
             'maxPage' => ceil(\count($articles) / $perPage),
-        ])->setLastModified(ContentUtils::max($pageArticles, 'lastModified'));
+        ])->setLastModified(ContentUtils::max($pageArticles, 'lastModifiedOrCreated'));
     }
 
     /**
@@ -60,7 +60,7 @@ class BlogController extends AbstractController
             'page' => $page,
             'minPage' => 1,
             'maxPage' => ceil(\count($articles) / $perPage),
-        ])->setLastModified(ContentUtils::max($pageArticles, 'lastModified'));
+        ])->setLastModified(ContentUtils::max($pageArticles, 'lastModifiedOrCreated'));
     }
 
     /**
@@ -70,6 +70,6 @@ class BlogController extends AbstractController
     {
         return $this->render('blog/article.html.twig', [
             'article' => $article,
-        ])->setLastModified($article->lastModified);
+        ])->setLastModified($article->getLastModifiedOrCreated());
     }
 }

--- a/src/Legacy/HtaccessGenerator.php
+++ b/src/Legacy/HtaccessGenerator.php
@@ -136,7 +136,7 @@ class HtaccessGenerator
         return $this->contentManager->getContents(
             Article::class,
             ['date' => false],
-            fn (Article $article) => $article->publishdate < $limit
+            fn (Article $article) => $article->date < $limit
         );
     }
 

--- a/src/Model/Article.php
+++ b/src/Model/Article.php
@@ -14,12 +14,17 @@ class Article
     public string $slug;
     public string $content;
     public ?\DateTimeImmutable $date = null;
-    public ?\DateTimeImmutable $publishdate = null;
-    public \DateTimeImmutable $lastModified;
+    public ?\DateTimeImmutable $lastModified = null;
     public bool $draft = true;
     public ?string $description;
+    /**
+     * Main image for the articles, used as thumbnail and banner.
+     */
     public string $thumbnail;
-    public string $header;
+    /**
+     * If provided, the image to use on top of the show article view instead of the thumbnail image.
+     */
+    public ?string $banner;
     public array $tags = [];
     public string $lang = 'fr';
     public array $categories;
@@ -62,5 +67,10 @@ class Article
         }
 
         return \in_array($author, $this->authors, true);
+    }
+
+    public function getLastModifiedOrCreated(): ?\DateTimeImmutable
+    {
+        return $this->lastModified ?? $this->date;
     }
 }

--- a/templates/blog/article.html.twig
+++ b/templates/blog/article.html.twig
@@ -25,7 +25,7 @@
     </ol>
 
     <div class="article-banner">
-        <div class="article-banner__cover" style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_banner') }}" data-aos="fade-down"></div>
+        <div class="article-banner__cover" style="{{ macros.backgroundImageSrcset(article.banner ?? article.thumbnail, 'article_banner') }}" data-aos="fade-down"></div>
 
         <div class="article-info" data-aos="zoom-in">
             {% set authors = article.authors|length > 5 ? [null] : article.authors %}
@@ -49,8 +49,10 @@
                 </div>
             {% endblock %}
             <div class="article-info__date">
-                <span>Publication <strong>{{ article.publishdate|format_date('long') }}</strong></span>
-                <span>Modification <strong>{{ article.lastModified|format_date('long') }}</strong></span>
+                <span>Publication <strong>{{ article.date|format_date('long') }}</strong></span>
+                {% if article.lastModified %}
+                    <span>Modification <strong>{{ article.lastModified|format_date('long') }}</strong></span>
+                {% endif %}
             </div>
         </div>
 

--- a/templates/blog/index.html.twig
+++ b/templates/blog/index.html.twig
@@ -34,7 +34,7 @@
                                     </span>
                                     <span class="article-author__info">
                                         Publication
-                                        <strong>{{ article.publishdate|format_date('medium') }}</strong>
+                                        <strong>{{ article.date|format_date('medium') }}</strong>
                                     </span>
                                 </div>
                             </div>
@@ -50,7 +50,7 @@
                             <span class="image" style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_thumbnail.md') }}"></span>
                         </a>
                         <div class="miniature-inline__content">
-                            <span class="date">{{ article.publishdate|format_date('medium')  }}</span>
+                            <span class="date">{{ article.date|format_date('medium')  }}</span>
                             <a href="{{ path('blog_article', { article: article.slug }) }}" class="title">{{ article.title }}</a>
                             <p class="description">{{ article.description }}</p>
                             {% block tags %}


### PR DESCRIPTION
Fixes #304 & normalise les méta des articles de blog

| Sans modif | Avec modif |
| - | - |
|![Capture d’écran 2021-05-04 à 16 00 27](https://user-images.githubusercontent.com/2211145/117015360-ee4c3680-acf1-11eb-9372-7b0e81d4c810.png)|![Capture d’écran 2021-05-04 à 16 00 14](https://user-images.githubusercontent.com/2211145/117015345-ea201900-acf1-11eb-9892-51cce87b29b9.png)|


En bonus, réintroduction des images utilisées comme bannières (différente des thumbnails) sur les anciens articles, et par conséquent on a cette même possibilité pour les nouveaux via la meta `banner` pour utiliser une image différente.

Exemple avec une banner différente de la thumbnail: https://elao.github.io/elao_/pr/316/blog/dev/two-ways-binding-avec-vue-et-vuex/

|Thumbnail|(Bruce) Banner|
|-|-|
|![Capture d’écran 2021-05-04 à 15 58 43](https://user-images.githubusercontent.com/2211145/117014983-a200f680-acf1-11eb-86dc-1efd1340555b.png)|![Capture d’écran 2021-05-04 à 15 58 36](https://user-images.githubusercontent.com/2211145/117014978-9f9e9c80-acf1-11eb-8772-d1311d5398cd.png)|


---

Requires https://github.com/StenopePHP/Stenope/pull/83 ✅ 