### PR TITLE
[Blog] Rework last modified on articles

### DIFF
--- a/content/blog/dev/donnees-structurees-offre-emploi.md
+++ b/content/blog/dev/donnees-structurees-offre-emploi.md
@@ -4,6 +4,7 @@ title:              "Mettez en valeur vos offres d'emploi grâce aux données st
 tableOfContent:     2
 
 description:        "Et si vous rendiez vos offres d'emploi plus visibles dans les pages de résultats des moteurs de recherche grâce aux données structurées ? "
+date:               "2019-08-26"
 
 thumbnail:          "images/posts/thumbnails/arrows-square.jpg"
 banner:             "images/posts/headers/arrows.jpg"

--- a/content/blog/styleguide/example.md
+++ b/content/blog/styleguide/example.md
@@ -2,7 +2,7 @@
 title:              "Petit guide de style du blog"
 date:               "2020-09-23"
 #lastModified:       ~ # A utiliser par défaut
-lastModified:       "2021-03-17" # A utiliser pour indiquer explicitement qu'un article a été mis à jour
+lastModified:       "2021-03-17" # A utiliser pour indiquer explicitement qu'un article a été mis à jour à une date. Supprimer la propriété pour utiliser la date de dernier commit.
 tableOfContent:     3
 
 description:        "Tour d'horizon de ce qu'on a pour faire de beaux articles. Et quelques bonnes pratiques de rédaction."

--- a/src/Model/Article.php
+++ b/src/Model/Article.php
@@ -14,7 +14,7 @@ class Article
     public string $title;
     public string $slug;
     public string $content;
-    public ?\DateTimeInterface $date = null;
+    public \DateTimeInterface $date;
     public ?\DateTimeInterface $lastModified = null;
     public bool $draft = true;
     public ?string $description;
@@ -70,7 +70,7 @@ class Article
         return \in_array($author, $this->authors, true);
     }
 
-    public function getLastModifiedOrCreated(): ?\DateTimeInterface
+    public function getLastModifiedOrCreated(): \DateTimeInterface
     {
         return $this->lastModified ?? $this->date;
     }

--- a/templates/blog/article.html.twig
+++ b/templates/blog/article.html.twig
@@ -55,7 +55,8 @@
             {% endblock %}
             <div class="article-info__date">
                 <span>Publication <strong>{{ article.date|format_date('long') }}</strong></span>
-                {% if article.lastModified %}
+                {# Do only display the last modified date if not null and different day than the publication date #}
+                {% if article.lastModified and article.lastModified > article.date|date_modify('+1 day 00:00') %}
                     <span>Modification <strong>{{ article.lastModified|format_date('long') }}</strong></span>
                 {% endif %}
             </div>


### PR DESCRIPTION
Suite à https://github.com/StenopePHP/Stenope/pull/101, on a maintenant une date de dernière modification cohérente disponible par défaut, se basant sur la date de dernier commit pour ce fichier.

Evidemment, pour les anciens articles réimportés dans le nouveau site, cette date serait incohérente. Il faut donc conserver le `lastModified: ~` explicite sur ceux-ci afin de désactiver la date de dernière modification.

Par contre, se pose la question sur le comportement que l'on souhaite par défaut pour les nouveaux articles ? A savoir:
1. `lastModified: ~` ➜ Date dernière modif désactivée, jusqu'à ce qu'on remplace explicitement par une date (ex: `lastModified: '2021-06-18'`) lors d'une mise à jour suffisamment importante de l'article. 
  **Inconvénient** principal: il faut y penser.
1. Absence de la propriété `lastModified` ➜ Date récupérée à partir de la date de dernier commit du fichier. Elle est automatiquement à jour, à la moindre typo / intervention sur l'article. 
  **Inconvénient**: ça peut donc avoir un impact lorsque l'on re-travaille les méta des articles dans une passe globale par exemple.