### PR TITLE
Allow WIP PRs to be deployed

### DIFF
--- a/.github/workflows/build_pr.yaml
+++ b/.github/workflows/build_pr.yaml
@@ -10,8 +10,8 @@ jobs:
     name: '🚧  Build & deploy 🚀'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Do not run on WIP or Draft PRs
-    if: "!github.event.pull_request || (!contains(github.event.pull_request.labels.*.name, 'wip 🛠') && github.event.pull_request.draft == false)"
+    # Do not run on Draft PRs
+    if: "!github.event.pull_request || github.event.pull_request.draft == false"
 
     steps:
       - name: 'Checkout'


### PR DESCRIPTION
Confusant de temps en temps, on garde le skip si la PR est en draft, mais si on utilise le label WIP pour simplement indiquer des changements en cours ou à venir suite à une 1ère step, on permet la preview.