### PR TITLE
[POC] Allow arbitrary "misc" pages

### DIFF
--- a/config/packages/stenope.yaml
+++ b/config/packages/stenope.yaml
@@ -15,6 +15,7 @@ stenope:
         App\Model\CaseStudy: '%kernel.project_dir%/content/case-study'
         App\Model\Member: '%kernel.project_dir%/content/member'
         App\Model\Technology: '%kernel.project_dir%/content/technologies'
+        App\Model\Misc: '%kernel.project_dir%/content/misc'
 
     resolve_links:
         App\Model\Member: { route: 'team_member', slug: 'member' }

--- a/content/misc/elaomojis.yaml
+++ b/content/misc/elaomojis.yaml
@@ -1,4 +1,11 @@
+twitterImage: social/elaomojis.jpg
+ogImage: social/elaomojis.jpg
+
 tweetId: ''
+
+title: "Notre sélection d'Elaomojis | Elao"
+description: "À l’occasion de la Journée Mondiale des Emojis 2021 (World Emoji Day), nous sommes ravis de vous présenter une sélection de nos :emojis-favoris: | Elao"
+
 categories:
     - title: "Le choix de l'équipe 🙋‍♀️🙆‍♂️"
       sections:

--- a/src/Controller/SiteController.php
+++ b/src/Controller/SiteController.php
@@ -6,12 +6,11 @@ namespace App\Controller;
 
 use App\Model\Article;
 use App\Model\Member;
+use App\Model\Misc;
 use Stenope\Bundle\ContentManager;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Yaml\Yaml;
 
 class SiteController extends AbstractController
 {
@@ -71,12 +70,10 @@ class SiteController extends AbstractController
     }
 
     #[Route('/elaomojis', name: 'elaomojis')]
-    public function elaomojis(ParameterBagInterface $parameterBag): Response
+    public function elaomojis(ContentManager $manager): Response
     {
-        $path = $parameterBag->get('kernel.project_dir') . '/templates/site/elaomojis.yaml';
-
         return $this->render('site/elaomojis.html.twig', [
-            'config' => Yaml::parseFile($path),
+            'config' => $manager->getContent(Misc::class, 'elaomojis'),
         ]);
     }
 }

--- a/src/Model/Misc.php
+++ b/src/Model/Misc.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+class Misc extends \stdClass
+{
+    use MetaTrait;
+}

--- a/src/Serializer/Normalizer/StdClassDenormalizer.php
+++ b/src/Serializer/Normalizer/StdClassDenormalizer.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Serializer\Normalizer;
+
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+class StdClassDenormalizer implements DenormalizerInterface, ContextAwareDenormalizerInterface, DenormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+
+    private const PROCESSING = 'std_class_processing';
+    private PropertyAccessorInterface $propertyAccessor;
+
+    public function __construct(PropertyAccessorInterface $propertyAccessor)
+    {
+        $this->propertyAccessor = $propertyAccessor;
+    }
+
+    public function denormalize($data, string $type, string $format = null, array $context = [])
+    {
+        $context[self::PROCESSING] = true;
+
+        /** @var \stdClass $object */
+        $object = $this->denormalizer->denormalize($data, $type, $format, $context);
+
+        foreach ($data as $key => $value) {
+            if (!$this->propertyAccessor->isReadable($object, $key)) {
+                $object->$key = $value;
+            }
+        }
+
+        return $object;
+    }
+
+    public function supportsDenormalization($data, string $type, string $format = null, array $context = [])
+    {
+        if (isset($context[self::PROCESSING])) {
+            return false;
+        }
+
+        return is_a($type, \stdClass::class, true);
+    }
+}

--- a/templates/site/elaomojis.html.twig
+++ b/templates/site/elaomojis.html.twig
@@ -1,11 +1,11 @@
 {% extends 'base.html.twig' %}
 
-{% block meta_title "Notre sélection d'Elaomojis | Elao" %}
-{% block meta_description "À l’occasion de la Journée Mondiale des Emojis 2021 (World Emoji Day), nous sommes ravis de vous présenter une sélection de nos :emojis-favoris: | Elao" %}
+{% block meta_title config.title %}
+{% block meta_description config.description %}
 
 {% block twitter_card_type 'summary_large_image' %}
-{% block og_image asset('social/elaomojis.jpg'|glide_image_preset('opengraph_image')) %}
-{% block twitter_image absolute_url(asset('social/elaomojis.jpg'|glide_image_preset('twitter_card'))) %}
+{% block og_image asset(config.ogImage|glide_image_preset('opengraph_image')) %}
+{% block twitter_image absolute_url(asset(config.twitterImage|glide_image_preset('twitter_card'))) %}
 
 {% block content %}
     <ol class="breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,7 +94,7 @@ Encore
         options.onBeforeSetupMiddleware = (devServer) => {
             const files = [
                 path.resolve(__dirname, 'templates/**/*.html.twig'),
-                path.resolve(__dirname, 'templates/site/elaomojis.yaml'),
+                path.resolve(__dirname, 'content/misc/elaomojis.yaml'),
             ]
 
             chokidar.watch(files).on('all', () => {


### PR DESCRIPTION
POC for https://github.com/StenopePHP/Stenope/issues/91#issuecomment-844415580

Such content pages allows any properties by relying on \stdClass specificities.
It just need creating once a class extending \stdClass. 
Then, any content, with various and different properties can be loaded with the content manager with its slug:

```php
$manager->getContent(Misc::class, 'elaomojis')
```

![Capture d’écran 2021-07-01 à 10 09 37](https://user-images.githubusercontent.com/2211145/124090374-0ff93e00-da55-11eb-818d-9629140015fa.png)
