### PR TITLE
Fix éléments non-interactifs si le JS est désactivé

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -6,6 +6,7 @@
 html.no-js [data-aos] {
   opacity: 1;
   transform: none;
+  pointer-events: unset;
 }
 
 // base


### PR DESCRIPTION
A cause d'AOS (le module qu'on utilise pour les animations au scroll),
certaines règles CSS de la lib désactivent les interactions tant que
l'animation n'est pas faite.
Si le navigateur a le JS désactivé, AOS ne s'exécute donc pas, mais la
règle CSS est tjrs là et rend l'interaction impossible (liens, boutons, ...)