### PR TITLE
[CI] Auto deploy on master push / merge PR to master

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,6 +2,9 @@ name: Deploy site
 
 on:
   workflow_dispatch: ~
+  push:
+    branches:
+      - master
 
 jobs:
 


### PR DESCRIPTION
[Sondage](https://elao.slack.com/archives/CQ6L47QUB/p1625568686024200) par rapport à ça. Mais étant donné que plusieurs se font avoir / posent la question, et qu'au contraire personne ne semble lever de contre-indication à le faire, autant deploy le site en production automatiquement suite à un merge / commit sur `master`.

Reste la question de la publication des articles (cf sondage) et au moins garder en tête que tout merge sur master == dispo immédiate pour l'instant.