### PR TITLE
[Blog] Fix date de dernière modification

### DIFF
--- a/content/blog/dev/les-attributs-php-8-dans-symfony.md
+++ b/content/blog/dev/les-attributs-php-8-dans-symfony.md
@@ -1,7 +1,7 @@
 ---
 title: 'Les attributs PHP 8 dans Symfony'
 date: '2021-07-06' # Au format YYYY-MM-DD
-#lastModified: '2021-06-25' # À utiliser pour indiquer explicitement qu'un article à été mis à jour
+lastModified: ~ # À utiliser pour indiquer explicitement qu'un article à été mis à jour
 description: 'Utilisation des attributs PHP 8 à la place des annotations.'
 author: mcolin # author|authors (multiple acceptés)
 #tableOfContent: true # `true` pour activer ou `3` pour lister les titres sur 3 niveaux.

--- a/content/blog/elao/anne-laure-developpeuse-web-chez-elao-depuis-3-ans.md
+++ b/content/blog/elao/anne-laure-developpeuse-web-chez-elao-depuis-3-ans.md
@@ -1,11 +1,12 @@
 ---
 title: 'Anne-Laure, développeuse web chez Elao depuis 3 ans'
 date: '2021-07-08' # Au format YYYY-MM-DD
+lastModified: ~
 description: ''
 authors: [cmozzati, aldeboissieu]
 tags: [elao, team]
 thumbnail: images/posts/2021/itw-2b.jpeg
-tweetId: '1413061065374580737' # Ajouter l'id du Tweet après publication.
+tweetId: '1413061065374580737'
 ---
 
 ## Ton parcours

--- a/content/blog/elao/trame-itw.md
+++ b/content/blog/elao/trame-itw.md
@@ -1,7 +1,7 @@
 ---
 title: '[Prénom], [poste] chez Elao depuis X ans'
 date: '2021-06-25' # Au format YYYY-MM-DD
-#lastModified: '2021-06-25' # À utiliser pour indiquer explicitement qu'un article à été mis à jour
+lastModified: ~ # À utiliser pour indiquer explicitement qu'un article à été mis à jour
 description: 'petite phrase sympa sur la personne'
 author: cmozzati # author|authors (multiple acceptés)
 #tableOfContent: true # `true` pour activer ou `3` pour lister les titres sur 3 niveaux.

--- a/src/Command/GenerateArticleCommand.php
+++ b/src/Command/GenerateArticleCommand.php
@@ -89,9 +89,9 @@ class GenerateArticleCommand extends Command
                 new Header(['title' => $title]),
                 new Header(['date' => $date], 'Au format YYYY-MM-DD'),
                 new Header(
-                    ['lastModified' => $date],
-                    'À utiliser pour indiquer explicitement qu\'un article à été mis à jour',
-                    false
+                    ['lastModified' => null],
+                    'Au format YYYY-MM-DD. Pour indiquer explicitement qu\'un article à été mis à jour',
+                    true
                 ),
                 new Header(['description' => $description]),
                 new Header(


### PR DESCRIPTION
https://www.elao.com/blog/dev/les-attributs-php-8-dans-symfony apparaît actuellement avec une date de modification correspondant au dernier commit. Or dans #359 on était parti sur le fait de demander explicitement à mettre à jour la date lors d'un changement important uniquement afin d'éviter qu'elle change à chaque typo/refacto des métas articles.

Pour ça, il faut donc que les métas indiquent une date nulle explicitement afin qu'elle ne soit pas calculée automatiquement par le `LastModifiedProcessor`. Le `make article` a donc été mis à jour en conséquence.