### PR TITLE
Fix named arguments

### DIFF
--- a/content/blog/dev/les-attributs-php-8-dans-symfony.md
+++ b/content/blog/dev/les-attributs-php-8-dans-symfony.md
@@ -69,7 +69,7 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class DefaultController extends AbstractController
 {
-  #[Route('/', methods=['GET'], name="homepage")]
+  #[Route('/', methods: ['GET'], name: "homepage")]
   public function homepage()
   {
   }
@@ -82,7 +82,7 @@ class DefaultController extends AbstractController
   }
 
   #[Route('/article/{article_slug}')]
-  #[Entity('article', expr='repository.findOneBySlug(article_slug)')]
+  #[Entity('article', expr: 'repository.findOneBySlug(article_slug)')]
   public function article(Article $article)
   {
   }
@@ -159,14 +159,14 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class Foobar
 {
-  #[Assert\Collection(fields=[
+  #[Assert\Collection(fields: [
     'email' => [
       new Assert\NotBlank,
       new Assert\Email,
     ],
     'description' => [
       new Assert\NotBlank,
-      new Assert\Length(min=10, max=255, message="Lorem ipsum")
+      new Assert\Length(min: 10, max: 255, message: "Lorem ipsum")
     ]
   ]]
   protected $contact;


### PR DESCRIPTION
Hello l'équipe !

C'est ma première PR ici, n'hésitez pas à demander s'il manque des choses :)

J'ai trouvé des petites erreurs avec les arguments nommés sur l'[article](https://www.elao.com/blog/dev/les-attributs-php-8-dans-symfony) des attributs PHP8 dans Symfony. Elles ont été introduite ici: dc88ac9e52d1181d9257306565728d0bd6044239 avec la PR #368.

Merci pour votre blog !!