### PR TITLE
[CI] Cache resized images to speed up deployments

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,6 +46,12 @@ jobs:
           ini-values: "memory_limit=-1"
           php-version: "8.1"
 
+      - name: 'Cache resized images'
+        uses: actions/cache@v2
+        with:
+          path: public/resized
+          key: resized-images-${{ github.workflow }}-${{ secrets.CACHE_VERSION }}
+
       - name: 'Determine composer cache directory'
         id: composer-cache
         run: echo "::set-output name=directory::$(composer config cache-dir)"

--- a/.github/workflows/deploy_pr_preview.yaml
+++ b/.github/workflows/deploy_pr_preview.yaml
@@ -40,6 +40,12 @@ jobs:
           ini-values: "memory_limit=-1"
           php-version: "8.1"
 
+      - name: 'Cache resized images'
+        uses: actions/cache@v2
+        with:
+          path: public/resized
+          key: resized-images-${{ github.workflow }}-${{ secrets.CACHE_VERSION }}
+
       - name: 'Determine composer cache directory'
         id: composer-cache
         run: echo "::set-output name=directory::$(composer config cache-dir)"

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -31,6 +31,12 @@ jobs:
           ini-values: "memory_limit=-1"
           php-version: "8.1"
 
+      - name: 'Cache resized images'
+        uses: actions/cache@v2
+        with:
+          path: public/resized
+          key: resized-images-${{ github.workflow }}-${{ secrets.CACHE_VERSION }}
+
       - name: 'Determine composer cache directory'
         id: composer-cache
         run: echo "::set-output name=directory::$(composer config cache-dir)"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,6 +30,12 @@ jobs:
           ini-values: "memory_limit=-1"
           php-version: "8.1"
 
+      - name: 'Cache resized images'
+        uses: actions/cache@v2
+        with:
+          path: public/resized
+          key: resized-images-${{ github.workflow }}-${{ secrets.CACHE_VERSION }}
+
       - name: 'Determine composer cache directory'
         id: composer-cache
         run: echo "::set-output name=directory::$(composer config cache-dir)"


### PR DESCRIPTION
Diff (le plus ancien run sans cache, le plus récent avec):

![Capture d’écran 2022-01-27 à 11 57 47](https://user-images.githubusercontent.com/2211145/151345939-8fd5922c-00fd-439e-961e-d2a0dca144b3.png)

Sans cache:

![Capture d’écran 2022-01-27 à 11 58 56](https://user-images.githubusercontent.com/2211145/151346015-2890b7e0-d475-4d50-9c00-1a63a723cf20.png)


Avec cache:

![Capture d’écran 2022-01-27 à 11 58 44](https://user-images.githubusercontent.com/2211145/151346039-1767d60b-1aff-4ebb-a98b-0c5feda31475.png)

---

Each workflow cache is independent.

Cache will only grow ; each time a new image is added, Glide will spot the resized version is missing and generate one.
However, if the original image is deleted, it'll not be removed from cache.

One can alter the CACHE_VERSION secret to renew the whole cache at once.

Cache TTL is 7days (https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy)