### PR TITLE
Typo: case to cache

### DIFF
--- a/content/blog/dev/apollo-graphql-cache.md
+++ b/content/blog/dev/apollo-graphql-cache.md
@@ -313,7 +313,7 @@ query Todo($id: ID!) {
 }
 ```
 
-Les deux requêtes utilisent les même données mais Apollo fera la seconde requête même si l'objet est déjà dans le case de la première car les données ne sont pas stockées avec la même clé de cache.
+Les deux requêtes utilisent les même données mais Apollo fera la seconde requête même si l'objet est déjà dans le cache de la première car les données ne sont pas stockées avec la même clé de cache.
 
 La redirection de cache permettra d'aller chercher ces données dans le cache d'une autre requête.
 


### PR DESCRIPTION
"... dans le `case` de la première..." -> "... dans le `cache` de la première..."