### PR TITLE
[Blog] Add keywords to structured data + add missing Symfony tag

### DIFF
--- a/content/blog/dev/stenope-skeleton.md
+++ b/content/blog/dev/stenope-skeleton.md
@@ -10,7 +10,7 @@ description: >
     pour vous aider à découvrir son utilisation et démarrer vos projets.
 
 thumbnail:          "content/images/blog/thumbnails/stenope-skeleton.jpg"
-tags:               ["Stenope", "Site Statique"]
+tags:               ["Stenope", "Site Statique", "Symfony"]
 authors:            ["msteinhausser"]
 tweetId:            "1570321529505710080"
 ---

--- a/src/Model/Article.php
+++ b/src/Model/Article.php
@@ -33,6 +33,8 @@ class Article
      * If provided, the image to use on top of the show article view instead of the thumbnail image.
      */
     public ?string $banner = null;
+
+    /** @var string[] */
     public array $tags = [];
 
     /**

--- a/templates/blog/article.html.twig
+++ b/templates/blog/article.html.twig
@@ -33,6 +33,11 @@
                     : path('team'),
                 ),
             }),
+            keywords: article.tags|map(tag => tag
+                |u.snake
+                |replace({ '_': ' ' })
+                |u.title
+            ),
         }|json_encode(
             constant('JSON_PRETTY_PRINT') b-or
             constant('JSON_UNESCAPED_SLASHES') b-or


### PR DESCRIPTION
Ajout des tags d'articles en tant que `keywords` dans les données structurées de [`NewsArticle`](https://schema.org/NewsArticle).

> **Note**: Les tags sont normalizés pour que les valeurs soient insensibles à la casse / espaces entre les mots.

![SCR-20220923-d16](https://user-images.githubusercontent.com/2211145/191910578-cfbad0ec-ce4b-4d81-87ea-1b65f1c7bd0e.png)
