### PR TITLE
[Layout] Fix elao address in footer

### DIFF
--- a/templates/partials/footer.html.twig
+++ b/templates/partials/footer.html.twig
@@ -69,8 +69,8 @@
                     <li>
                         <a href="mailto://{{ site.contact.email }}">{{ site.contact.email }}</a>
                     </li>
-                    <li>36 rue Jean Broquin</li>
-                    <li>69006 LYON</li>
+                    <li>{{ site.contact.address.street_address }}</li>
+                    <li>{{ site.contact.address.address_locality }}</li>
                 </ul>
             </div>
         </section>


### PR DESCRIPTION
L'adresse d'elao dans le pied de page mentionne le `36 rue Jean BROQUIN` (au lieu du 34)

Aperçu : https://elao.github.io/elao_/pr/576/