### PR TITLE
[CONTENT] Fix previous PR 'add-glossary-links'

### DIFF
--- a/assets/scss/pages/_page-methodology.scss
+++ b/assets/scss/pages/_page-methodology.scss
@@ -153,6 +153,14 @@
 
           a {
             color: #fff;
+            text-decoration: underline;
+            transition: color ease-in .1s;
+
+            &:hover,
+            &:active,
+            &:focus {
+              color: $color-brand;
+            }
           }
         }
       }

--- a/assets/scss/pages/_page-services.scss
+++ b/assets/scss/pages/_page-services.scss
@@ -290,6 +290,18 @@
 
       li {
         font-size: 17px;
+
+        a {
+          color: #fff;
+          text-decoration: underline;
+          transition: color ease-in .1s;
+
+          &:hover,
+          &:active,
+          &:focus {
+            color: $color-brand;
+          }
+        }
       }
 
       span {
@@ -313,12 +325,25 @@
       padding: 20px 40px;
       margin-bottom: 10px;
       color: $color-text;
+
       &:before, &:after {
         display: none;
       }
 
       .icon {
         font-size: 40px;
+      }
+
+      a {
+        color: $color-text;
+        text-decoration: underline;
+        transition: color ease-in .1s;
+
+        &:hover,
+        &:active,
+        &:focus {
+          color: $color-brand;
+        }
       }
     }
   }

--- a/templates/partials/ia-brief.html.twig
+++ b/templates/partials/ia-brief.html.twig
@@ -2,7 +2,7 @@
 <p>
     Vous avez une idée de projet et vous souhaitez mesurer sa viabilité ? Vous avez besoin d'optimiser vos données
     métiers ? Vous souhaitez accélérer votre projet ? Nous avons conçu notre assistant,
-    <a href="{{ amabla.url }}" target="_blank" title="{{ amabla.seoTitle }}">Amabla</a>,
+    <strong><a href="{{ amabla.url }}" target="_blank" title="{{ amabla.seoTitle }}">Amabla</a></strong>,
     basé sur les <strong><a href="{{ path('glossary_term', {term: 'ia'}) }}">IA génératives</a></strong>
     qui vous permettra <strong>d'affiner vos besoins</strong>, définir vos <strong>priorités</strong>
     et <strong>construire</strong> les bases de nos futurs échanges.

--- a/templates/site/home.html.twig
+++ b/templates/site/home.html.twig
@@ -169,7 +169,7 @@
                             <li>IA génératives</li>
                             <li>Assistants personnalisés</li>
                             <li>Intégration ChatGPT</li>
-                            <li><a href="{{ amabla.url }}" target="_blank" title="{{ amabla.seoTitle }}">Amabla ©</a></li>
+                            <li><strong><a href="{{ amabla.url }}" target="_blank" title="{{ amabla.seoTitle }}">Amabla ©</a></strong></li>
                         </ul>
                         <a href="{{ path('ia') }}" class="link link--brand">En savoir plus</a>
                     </li>
@@ -189,7 +189,7 @@
                     </div>
                     <p>Nous sommes avant tout des experts sur les technologies que nous utilisons au quotidien, avec principalement :</p>
                     <ul>
-                        <li><strong><a href="{{ path('glossary_term', {term: 'symfony'}) }}">Symfony</a></strong>, LE <strong>framework <a href="{{ path('glossary_term', {term: 'php'}) }}">PHP</a></strong> que nous utilisons depuis notre création (nous avons mis notre première application web en ligne en 2006, avant la version 1 de <strong><a href="{{ path('glossary_term', {term: 'symfony'}) }}">Symfony</a></strong> !). On aime son efficacité, sa modularité, sa robustesse et le dynamisme de sa communauté qui en a fait une référence depuis presque 20 ans.</li>
+                        <li><strong><a href="{{ path('glossary_term', {term: 'symfony'}) }}">Symfony</a></strong>, LE <strong>framework <a href="{{ path('glossary_term', {term: 'php'}) }}">PHP</a></strong> que nous utilisons depuis notre création (nous avons mis notre première application web en ligne en 2006, avant la version 1 de Symfony !). On aime son efficacité, sa modularité, sa robustesse et le dynamisme de sa communauté qui en a fait une référence depuis presque 20 ans.</li>
                         <li><strong><a href="{{ path('glossary_term', {term: 'react'}) }}">React/ReactNative</a></strong>, pour le côté front, qui va rendre vos sites et vos applications dynamiques, responsives et permettre une expérience utilisateurs optimale.</li>
                     </ul>
                     <p>Nous faisons le choix de technologies éprouvées, reconnues et maintenables, vous garantissant les solutions les plus qualitatives, robustes et évolutives possibles.</p>

--- a/templates/site/services/application.html.twig
+++ b/templates/site/services/application.html.twig
@@ -109,7 +109,7 @@
             <div>
                 <h3>Architecture applicative</h3>
                 <p><strong>Notre approche centrée sur le produit </strong>impacte également la structure de notre code. Nous essayons de découpler au maximum le code métier, qui porte le plus de valeur ajoutée, du framework, qui sert juste à le mettre en œuvre.</p>
-                <p>Ce type d'architecture que l'on nomme <a href="{{ path('glossary_term', {term: 'ddd'}) }}">DDD</a> permet également de faciliter la mise en place de tests automatiques et de se rendre moins dépendant des montées de version du framework.</p>
+                <p>Ce type d'architecture que l'on nomme <strong><a href="{{ path('glossary_term', {term: 'ddd'}) }}">DDD</a></strong> permet également de faciliter la mise en place de tests automatiques et de se rendre moins dépendant des montées de version du framework.</p>
             </div>
         </div>
 

--- a/templates/site/services/consulting.html.twig
+++ b/templates/site/services/consulting.html.twig
@@ -107,7 +107,9 @@
                 {% set delay = delay + delayGap %}
                 <li class="supports__item" data-aos="fade-up" data-aos-duration="{{ duration }}" data-aos-delay="{{ delay }}">
                     <i class="icon icon--backlog" aria-hidden="true"></i>
-                    Construire avec vous le backlog de votre produit
+                    <span class="supports__item__content">
+                        Construire avec vous le <strong><a href="{{ path('glossary_term', {term: 'backlog'}) }}">backlog</a></strong> de votre produit
+                    </span>
                 </li>
                 {% set delay = delay + delayGap %}
                 <li class="supports__item" data-aos="fade-up" data-aos-duration="{{ duration }}" data-aos-delay="{{ delay }}">

--- a/templates/site/services/ia.html.twig
+++ b/templates/site/services/ia.html.twig
@@ -22,7 +22,8 @@
                      data-aos="fade-left"
                      style="background-image: {{ asset('build/images/pages/services/ia/ia-banner.jpg') }};
                             background-image: image-set(url({{ asset('build/images/pages/services/ia/ia-banner.jpg') }}) 1x,
-                                                        url({{ asset('build/images/pages/services/ia/ia-banner@2x.jpg') }}) 2x);"></div>
+                                                        url({{ asset('build/images/pages/services/ia/ia-banner@2x.jpg') }}) 2x);">
+                </div>
                 <span class="highlight" data-aos="zoom-in">
                     <p>Chez Elao, nous voyons en l'IA un allié de taille pour nous aider dans nos tâches quotidiennes</p>
                 </span>
@@ -32,9 +33,20 @@
         <div class="page-ia">
             <h2 class="h2--dash">Elao et l'IA</h2>
             <div class="offset-content">
-                <p>Chez Elao, nous voyons <strong><a href="{{ path('glossary_term', {term: 'ia'}) }}">l'IA</a></strong> comme un outil <strong>puissant</strong> et <strong>polyvalent</strong> qui nous permet de <strong>gagner un temps précieux</strong> et de concentrer nos efforts là où nous avons de la <strong>véritable valeur</strong>.</p>
-                <p>Face à cette affirmation, nous nous sommes demandés comment faire de l'IA un outil quotidien donnant une <strong>forte valeur ajoutée à nos tâches récurrentes</strong>.</p>
-                <p>Notre idée : faire de cet outil technologique un allié de tous les jours plutôt qu'un mastodonte effrayant.</p>
+                <p>
+                    Chez Elao, nous voyons
+                    <strong><a href="{{ path('glossary_term', {term: 'ia'}) }}">l'IA</a></strong> comme un outil
+                    <strong>puissant</strong> et <strong>polyvalent</strong> qui nous permet
+                    de <strong>gagner un temps précieux</strong> et de concentrer nos efforts là où nous avons de
+                    la <strong>véritable valeur</strong>.</p>
+                <p>
+                    Face à cette affirmation, nous nous sommes demandés comment faire de l'IA un outil quotidien
+                    donnant une <strong>forte valeur ajoutée à nos tâches récurrentes</strong>.
+                </p>
+                <p>
+                    Notre idée : faire de cet outil technologique un allié
+                    de tous les jours plutôt qu'un mastodonte effrayant.
+                </p>
             </div>
 
             {% include 'partials/amabla-brief-incentive.html.twig' %}
@@ -44,7 +56,7 @@
             </h2>
             <div class="illustrated-section" data-aos="fade-left">
                 <div class="illustrated-section__content">
-                    <p>Né de l'envie d'intégrer l'IA dans notre quotidien, ce projet s'est rapidement imposé comme une réponse à un besoin plus large : proposer des <strong>assistants personalisés capables d'interagir avec les nombreux modèles d'IA présents et à venir.</p>
+                    <p>Né de l'envie d'intégrer l'IA dans notre quotidien, ce projet s'est rapidement imposé comme une réponse à un besoin plus large : proposer des <strong>assistants personalisés capables d'interagir avec les nombreux modèles d'IA présents et à venir.</strong></p>
                     <p>Depuis plusieurs mois, les équipes d'Elao travaillent sur ce projet avec une idée en tête : permettre à nos clients d'exploiter toute puissance de l'IA dans un <strong>contexte défini pour répondre à des besoins métiers spéficiques</strong>.</p>
                     <p>Aujourd'hui nous vous proposons, à travers une interface de génération de brief, de tester une première application de cet outil. <strong>Mais ce n'est qu'un usage parmi d'autres, et la liste des possibles est infini : </strong> que cela soit pour vous aider à générer du contenu, à concevoir vos argumentaires commerciaux, à réaliser vos rapports journaliers, à synthétiser vos documents, etc.</p>
                     <a

--- a/templates/site/services/services.html.twig
+++ b/templates/site/services/services.html.twig
@@ -147,9 +147,8 @@
                         <strong>outil</strong> nous permettant de gagner du temps dans nos tâches quotidiennes
                         afin de nous focaliser sur notre valeur ajoutée. De l'intégration dans votre site
                         à l'utilisation
-                        d'<a href="{{ amabla.url }}" target="_blank" title="{{ amabla.seoTitle }}">Amabla</a>,
-                        <strong>un service d'assistants sur-mesure</strong> basé sur
-                        <strong><a href="{{ path('glossary_term', {term: 'ia'}) }}">l'IA générative</a></strong>,
+                        d'<strong><a href="{{ amabla.url }}" target="_blank" title="{{ amabla.seoTitle }}">Amabla</a></strong>,
+                        <strong>un service d'assistants sur-mesure</strong> basé sur l'IA générative,
                         nous concevons avec vous des solutions permettant de répondre à vos besoins métier.
                     </p>
                     <a href="{{ path('ia') }}" class="btn btn--secondary btn--animated" data-aos="fade-left">


### PR DESCRIPTION
### TODO ### 

Quelques fixs remontés par @evaelao sur https://github.com/Elao/elao_/pull/595

- [x] **Pages home, méthodologie, services : consulting / hosting / ia, valeurs** : mettre les liens en gras 

- [x] **Page home** : **supprimer le deuxième lien vers le glossaire 'Symfony'**

- [x] **Page home** : Enlever le 2e lien sur 'IA générative' dans le bloc 'Solutions basées sur l'IA' 

- [x] **Page méthodo** : **dans la card bleue (.build__steps) les liens doivent avoir un underline (soulignés)**

- [x] **Page nos-services/ia** : **les colonnes sont réduites à partir de "C'est quoi Amabla" + tout le reste est en gras...** -> **balise '< / strong >' qui a disparu lors dernière MEP** : à rajouter

- [x] **Page application** : mettre le lien 'DDD' en gras

- [x] **Page consulting** : sur les encarts bleus ; appliquer le même style pour les liens ; en blanc soulignés

- [x] **Page consulting** : ajouter un lien vers le glossaire pour 'backlog'

