### PR TITLE
fix mailto

### DIFF
--- a/templates/partials/brick-contact.html.twig
+++ b/templates/partials/brick-contact.html.twig
@@ -6,6 +6,6 @@
     </address>
     <address>
         <i class="icon icon--write"></i>
-        <a href="mailto://{{ site.contact.email }}">{{ site.contact.email }}</a>
+        <a href="mailto:{{ site.contact.email }}">{{ site.contact.email }}</a>
     </address>
 </div>

--- a/templates/partials/footer.html.twig
+++ b/templates/partials/footer.html.twig
@@ -67,7 +67,7 @@
                         <a href="tel://{{ site.contact.phone }}">{{ site.contact.phone }}</a>
                     </li>
                     <li>
-                        <a href="mailto://{{ site.contact.email }}">{{ site.contact.email }}</a>
+                        <a href="mailto:{{ site.contact.email }}">{{ site.contact.email }}</a>
                     </li>
                     <li>{{ site.contact.address.street_address }}</li>
                     <li>{{ site.contact.address.address_postalCode }} {{ site.contact.address.address_locality }}</li>


### PR DESCRIPTION
Retire les // dans le mailto, y avait notamment le lien de contact dans le footer qui était cassé à cause de ça : 

![SCR-20240417-jj0](https://github.com/Elao/elao_/assets/606766/8e943864-153b-45b0-b1f6-d42dd04abdb2)
