### PR TITLE
[Blog][Team] Added meta members

### DIFF
--- a/content/member/elao.yaml
+++ b/content/member/elao.yaml
@@ -1,4 +1,5 @@
-active: false
+meta: true # Group of members
+active: true
 
 name: La team Elao
 position: "Atelier de conception d'applications web et mobile sur-mesure | Experts Symfony et React"

--- a/src/Controller/BlogController.php
+++ b/src/Controller/BlogController.php
@@ -66,7 +66,7 @@ class BlogController extends AbstractController
 
     #[Route('/auteur/{author}', name: 'blog_author')]
     #[Route('/auteur/{author}/{!page}', name: 'blog_author_page', requirements: ['page' => '\d+'])]
-    public function articlesFromAuthor(Request $request, Member $author, int $page = 1, int $perPage = 20): Response
+    public function articlesFromAuthor(Member $author, int $page = 1, int $perPage = 20): Response
     {
         $articles = $this->manager->getContents(
             Article::class,

--- a/src/Controller/SiteController.php
+++ b/src/Controller/SiteController.php
@@ -20,7 +20,7 @@ class SiteController extends AbstractController
     {
         /** @var Article[] $articles */
         $articles = $manager->getContents(Article::class, ['date' => false]);
-        $members = $manager->getContents(Member::class, [], ['active' => true]);
+        $members = $manager->getContents(Member::class, [], ['active' => true, 'meta' => false]);
         $caseStudies = $manager->getContents(CaseStudy::class, ['date' => false], ['enabled' => true]);
 
         return $this->render('site/home.html.twig', [
@@ -51,7 +51,7 @@ class SiteController extends AbstractController
     #[Route('/nos-valeurs', name: 'values')]
     public function values(ContentManagerInterface $manager): Response
     {
-        $activeMembers = $manager->getContents(Member::class, null, static fn (Member $member): bool => $member->active);
+        $activeMembers = $manager->getContents(Member::class, null, ['active' => true, 'meta' => false]);
         $count = \count($activeMembers);
         $velotafCount = \count(array_filter($activeMembers, static fn (Member $member): bool => $member->🚲));
 

--- a/src/Controller/TeamController.php
+++ b/src/Controller/TeamController.php
@@ -26,7 +26,7 @@ class TeamController extends AbstractController
     #[Route(name: 'team')]
     public function list(): Response
     {
-        $members = $this->manager->getContents(Member::class, ['name' => true], ['active' => true]);
+        $members = $this->manager->getContents(Member::class, ['name' => true], ['active' => true, 'meta' => false]);
 
         return $this->render('team/index.html.twig', [
             'members' => $members,

--- a/src/Model/Member.php
+++ b/src/Model/Member.php
@@ -6,10 +6,11 @@ namespace App\Model;
 
 use Stenope\Bundle\Attribute\SuggestedDebugQuery;
 
-#[SuggestedDebugQuery('Actifs', filters: '_.active', orders: 'desc:integrationDate')]
-#[SuggestedDebugQuery('Anciens', filters: 'not _.active', orders: 'desc:integrationDate')]
-#[SuggestedDebugQuery('Vélotaffeurs', filters: '_.🚲 and _.active', orders: 'desc:integrationDate')]
-#[SuggestedDebugQuery('Piétons', filters: 'not _.🚲 and _.active', orders: 'desc:integrationDate')]
+#[SuggestedDebugQuery('Actifs', filters: '_.active and not _.meta', orders: 'desc:integrationDate')]
+#[SuggestedDebugQuery('Anciens', filters: 'not _.active and not _.meta', orders: 'desc:integrationDate')]
+#[SuggestedDebugQuery('Vélotaffeurs', filters: '_.🚲 and _.active and not _.meta', orders: 'desc:integrationDate')]
+#[SuggestedDebugQuery('Piétons', filters: 'not _.🚲 and _.active and not _.meta', orders: 'desc:integrationDate')]
+#[SuggestedDebugQuery('Meta members', filters: '_.meta', orders: 'desc:integrationDate')]
 class Member
 {
     public string $slug;
@@ -45,6 +46,9 @@ class Member
     // Flags
 
     public bool $active = false;
+
+    /** Group of members: ex: "La team elao" */
+    public bool $meta = false;
 
     /** Vélotafeur */
     public bool $🚲 = false;

--- a/src/Stenope/Listener/BuildListener.php
+++ b/src/Stenope/Listener/BuildListener.php
@@ -37,7 +37,7 @@ class BuildListener implements EventSubscriberInterface
         // For each active member, we pre-generate their mail signature URLs,
         // so it's included in the build despite not being linked anywhere:
         /** @var Member $member */
-        foreach ($this->manager->getContents(Member::class, [], ['active' => true]) as $member) {
+        foreach ($this->manager->getContents(Member::class, [], ['active' => true, 'meta' => false]) as $member) {
             $this->urlGenerator->generate('team_member_mail_signature', ['member' => $member->slug]);
         }
     }
@@ -45,7 +45,7 @@ class BuildListener implements EventSubscriberInterface
     private function addLegacyTeamMemberRedirects(): void
     {
         /** @var Member $member */
-        foreach ($this->manager->getContents(Member::class, [], ['active' => true]) as $member) {
+        foreach ($this->manager->getContents(Member::class, [], ['active' => true, 'meta' => false]) as $member) {
             $this->urlGenerator->generate('app_legacyteam_show', ['member' => $member->slug]);
         }
     }

--- a/templates/blog/article.html.twig
+++ b/templates/blog/article.html.twig
@@ -26,7 +26,7 @@
             author: article.authorsArray | map(author => {
                 '@type': 'Person',
                 name: author.name,
-                url: author.active
+                url: (author.active and not author.meta)
                     ? url('team_member', { member: author.slug })
                     : url('team')
                 ,
@@ -85,7 +85,9 @@
                                     <strong>{{ author.name }}</strong>
                                 </a>
                             {% else %}
-                                <strong>La team elao</strong>
+                                <a href="{{ path('blog_author', { author: 'elao' }) }}">
+                                    <strong>La team elao</strong>
+                                </a>
                             {% endfor %}
                         </span>
                     </div>

--- a/templates/blog/author.html.twig
+++ b/templates/blog/author.html.twig
@@ -19,7 +19,7 @@
 
         <div class="article-author article-author--large">
             <div class="article-author__image">
-                {% if author.active %}
+                {% if author.active and not author.meta %}
                     <a href="{{ path('team_member', { member: author.slug }) }}">
                         <img {{ macros.imageSrcset(author.avatar(), 'author_avatar') }} />
                     </a>
@@ -29,7 +29,7 @@
             </div>
             <span class="article-author__info">
                 Les articles de
-                {% if author.active %}
+                {% if author.active and not author.meta %}
                     <a href="{{ path('team_member', { member: author.slug }) }}">
                         <strong>{{ author.name }}</strong>
                     </a>

--- a/templates/blog/index.html.twig
+++ b/templates/blog/index.html.twig
@@ -38,7 +38,9 @@
                                                 <strong>{{ author.name }}</strong>
                                             </a>
                                         {% else %}
-                                            <strong>La team elao</strong>
+                                            <a href="{{ path('blog_author', { author: 'elao' }) }}">
+                                                <strong>La team elao</strong>
+                                            </a>
                                         {% endfor %}
                                     </span>
                                     <span class="article-author__info">

--- a/templates/case_study/show.html.twig
+++ b/templates/case_study/show.html.twig
@@ -100,7 +100,7 @@
                     {% set member = content_get('App\\Model\\Member', memberSlug) %}
                     <li class="project-team__member" data-aos="fade-in" data-aos-delay="{{ loop.index * 150 }}">
                         <a
-                            {%- if member.active %}
+                            {%- if member.active and not member.meta %}
                                 href="{{ path('team_member', { member: member.slug }) }}"
                             {% endif -%}
                         >

--- a/templates/site/innovation-workshop.html.twig
+++ b/templates/site/innovation-workshop.html.twig
@@ -123,7 +123,7 @@
                         </span>
                     </div>
                     <div class="thumbnail">
-                        {% set membersCount = content_list('App\\Model\\Member', filterBy = '_.active') | length %}
+                        {% set membersCount = content_list('App\\Model\\Member', filterBy = '_.active and not _.meta') | length %}
                         <span class="number">{{ membersCount }}</span>
                         <span class="detail">expert·e·s passionné·e·s</span>
                         <a href="{{ path('team') }}">


### PR DESCRIPTION
Ex: "Team elao", "Amabla", …

Allows to have a link to list such authors' contents on the blog, but without having a team page entry: https://elao.github.io/elao_/pr/615/blog/auteur/elao/

![image](https://github.com/Elao/elao_/assets/2211145/7eab334d-e3fb-48f0-872c-fec3b9b9d83d)
