### PR TITLE
[Blog] Allow to provide resize options for thumbnails / banner

### DIFF
--- a/content/blog/dev/apollo-mock-data-local-resolvers.md
+++ b/content/blog/dev/apollo-mock-data-local-resolvers.md
@@ -9,6 +9,13 @@ authors: [msteinhausser]
 tableOfContent: 3
 tags: [javascript, apollo, graphql, api]
 thumbnail: content/images/blog/2024/apollo-mock-data-local-resolvers/apollo-local-resolvers-2.png
+thumbnailResizeOptions:
+  article_thumbnail.lg:
+      fit: fill
+      bg: white
+bannerResizeOptions:
+  fit: fill
+  bg: white
 tweetId: "1810590609163309213"
 outdated: false
 ---

--- a/src/Model/Article.php
+++ b/src/Model/Article.php
@@ -10,6 +10,10 @@ use Stenope\Bundle\Attribute\SuggestedDebugQuery;
 use Stenope\Bundle\Processor\TableOfContentProcessor;
 use Stenope\Bundle\TableOfContent\TableOfContent;
 
+/**
+ * @phpstan-type ThumbnailPreset "article_thumbnail.xs" | "article_thumbnail.sm" | "article_thumbnail.md" | "article_thumbnail.lg"
+ * @phpstan-type BannerPreset "article_banner"
+ */
 #[SuggestedDebugQuery('Scheduled', filters: 'not _.isPublished()', orders: 'desc:date')]
 #[SuggestedDebugQuery('Outdated', filters: '_.outdated', orders: 'desc:date')]
 #[SuggestedDebugQuery('Written in english', filters: '_.lang == "en"', orders: 'desc:date')]
@@ -30,9 +34,30 @@ class Article
      */
     public string $thumbnail;
     /**
+     * Allows to provide resize options specific to this article if needed.
+     * It allows a more fine-grained control over the rendering of the same image in different context,
+     * and can even provide options per preset used.
+     *
+     * @var array<string, array>|array<ThumbnailPreset, array<string, array>> Preset name as key, options as value
+     *
+     * @see https://glide.thephpleague.com/1.0/api/quick-reference/
+     */
+    public ?array $thumbnailResizeOptions = null;
+
+    /**
      * If provided, the image to use on top of the show article view instead of the thumbnail image.
      */
     public ?string $banner = null;
+    /**
+     * Allows to provide resize options specific to this article if needed.
+     * It allows a more fine-grained control over the rendering of the same image in different context,
+     * and can even provide options per preset used.
+     *
+     * @var array<string, array>|array<ThumbnailPreset, array<string, array>> Preset name as key, options as value
+     *
+     * @see https://glide.thephpleague.com/1.0/api/quick-reference/
+     */
+    public ?array $bannerResizeOptions = null;
 
     /** @var string[] */
     public array $tags = [];

--- a/templates/blog/article.html.twig
+++ b/templates/blog/article.html.twig
@@ -63,7 +63,11 @@
         {% endwith %}
 
         <div class="article-banner">
-            <div class="article-banner__cover" style="{{ macros.backgroundImageSrcset(article.banner ?? article.thumbnail, 'article_banner') }}" data-aos="fade-down"></div>
+            <div
+                class="article-banner__cover"
+                style="{{ macros.backgroundImageSrcset(article.banner ?? article.thumbnail, 'article_banner', null, article.bannerResizeOptions) }}"
+                data-aos="fade-down"
+            ></div>
 
             <div class="article-info" data-aos="zoom-in">
                 {% set authors = article.authors|length > 5 ? [] : article.authors %}

--- a/templates/blog/index.html.twig
+++ b/templates/blog/index.html.twig
@@ -16,7 +16,10 @@
                 {% if page == minPage and loop.first %}
                     <li class="miniature-highlight">
                         <a href="{{ path('blog_article', { article: article.slug }) }}" class="miniature-highlight__image" data-aos="fade-down">
-                            <span class="image" style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_thumbnail.lg') }}"></span>
+                            <span
+                                class="image"
+                                style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_thumbnail.lg', null, article.thumbnailResizeOptions) }}"
+                            ></span>
                         </a>
                         <div class="miniature-highlight__content" data-aos="zoom-in">
                             <div class="info">
@@ -69,7 +72,10 @@
                 {% elseif page == minPage and loop.index < 5 %}
                     <li class="miniature-inline" data-aos="fade-left">
                         <a href="{{ path('blog_article', { article: article.slug }) }}" class="miniature-inline__image">
-                            <span class="image" style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_thumbnail.md') }}"></span>
+                            <span
+                                class="image"
+                                style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_thumbnail.md', null, article.thumbnailResizeOptions) }}"
+                            ></span>
                         </a>
                         <div class="miniature-inline__content">
                             <span class="date">{{ article.date|format_datetime('short', 'none', locale='fr') }}</span>
@@ -97,7 +103,10 @@
                 {% else %}
                     <li class="miniature" data-aos="fade-in">
                         <a href="{{ path('blog_article', { article: article.slug }) }}" class="miniature__image">
-                            <span class="image" style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_thumbnail.sm') }}"></span>
+                            <span
+                                class="image"
+                                style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_thumbnail.sm', null, article.thumbnailResizeOptions) }}"
+                            ></span>
                         </a>
                         <div class="miniature__content">
                             <a href="{{ path('blog_article', { article: article.slug }) }}" class="title">{{ article.title }}</a>

--- a/templates/glossary/index.html.twig
+++ b/templates/glossary/index.html.twig
@@ -56,7 +56,10 @@
                 {% set url = path('blog_article', { article: article.slug }) %}
                 <li class="miniature aos-init aos-animate fade-in" data-aos="fade-in" data-aos-delay="{{ (loop.index / loop.length)|round(0, 'ceil') * 150 }}">
                     <a href="{{ url }}" class="miniature__image">
-                        <span class="image" style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_thumbnail.sm') }}">
+                        <span
+                            class="image"
+                            style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_thumbnail.sm', null, article.thumbnailResizeOptions) }}"
+                        >
                         </span>
                     </a>
                     <div class="miniature__content">

--- a/templates/glossary/term.html.twig
+++ b/templates/glossary/term.html.twig
@@ -61,7 +61,10 @@
                         {% set url = path('blog_article', { article: article.slug }) %}
                         <li class="miniature" data-aos="fade-in" data-aos-delay="{{ (loop.index / 4)|round(0, 'ceil') * 150 }}">
                         <a href="{{ url }}" class="miniature__image">
-                            <span class="image" style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_thumbnail.sm') }}"></span>
+                            <span
+                                class="image"
+                                style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_thumbnail.sm', null, article.thumbnailResizeOptions) }}"
+                            ></span>
                         </a>
                         <div class="miniature__content">
                             <a href="{{ url }}" class="title">{{ article.title }}</a>

--- a/templates/macros.html.twig
+++ b/templates/macros.html.twig
@@ -1,14 +1,18 @@
-{% macro backgroundImageSrcset(path, preset, bgColor = '#f1f1f1') -%}
-    background: {{ bgColor }} url('{{ asset(path|glide_image_preset(preset)) }}');
+{% macro backgroundImageSrcset(path, preset, bgColor, options) -%}
+    {%- set bgColor = bgColor ?? '#f1f1f1' -%}
+    {%- set options = options ?? {} -%}
+    {# Check for specific entry for the preset name: #}
+    {%- set options = options[preset] ?? options -%}
+    background: {{ bgColor }} url('{{ asset(path|glide_image_preset(preset, options)) }}');
     {% for prefix in ['webkit', 'moz', 'ms'] -%}
     background: {{ bgColor }} -{{ prefix }}-image-set(
-        url('{{ asset(path|glide_image_preset(preset)) }}') 1x,
-        url('{{ asset(path|glide_image_preset(preset, { dpr: 2 })) }}') 2x
+        url('{{ asset(path|glide_image_preset(preset, options)) }}') 1x,
+        url('{{ asset(path|glide_image_preset(preset, options|merge({ dpr: 2 }))) }}') 2x
     );
     {% endfor -%}
     background: {{ bgColor }} image-set(
-        url('{{ asset(path|glide_image_preset(preset)) }}') 1x,
-        url('{{ asset(path|glide_image_preset(preset, { dpr: 2 })) }}') 2x
+        url('{{ asset(path|glide_image_preset(preset, options)) }}') 1x,
+        url('{{ asset(path|glide_image_preset(preset, options|merge({ dpr: 2 }))) }}') 2x
     );
 {%- endmacro %}
 

--- a/templates/site/home.html.twig
+++ b/templates/site/home.html.twig
@@ -262,7 +262,10 @@
                     {% for article in lastTwoArticles %}
                     <li class="last-article">
                         <a href="{{ path('blog_article', { article: article.slug }) }}" class="last-article__image" data-aos="fade-down">
-                            <span class="image" style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_thumbnail.md') }}"></span>
+                            <span
+                                class="image"
+                                style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_thumbnail.md', null, article.thumbnailResizeOptions) }}"
+                            ></span>
                         </a>
                         <div class="last-article__content" data-aos="zoom-in">
                             <div class="info">

--- a/templates/team/member.html.twig
+++ b/templates/team/member.html.twig
@@ -147,7 +147,10 @@
                             {% for article in articles %}
                                 <div class="miniature-inline miniature-inline--small" data-aos="fade-in" data-aos-delay="{{ loop.index0 * 100 }}">
                                     <a href="{{ path('blog_article', { article: article.slug }) }}" class="miniature-inline__image">
-                                        <span class="image" style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_thumbnail.xs') }}"></span>
+                                        <span
+                                            class="image"
+                                            style="{{ macros.backgroundImageSrcset(article.thumbnail, 'article_thumbnail.xs', null, article.thumbnailResizeOptions) }}"
+                                        ></span>
                                     </a>
                                     <div class="miniature-inline__content">
                                         <a href="{{ path('blog_article', { article: article.slug }) }}" class="title">{{ article.title }}</a>


### PR DESCRIPTION
It allows a more fine-grained control over the rendering of the same image in different context, per article,
and can even provide options per preset used.

For instance, I can control the resize of the `article_thumbnail.lg` preset to avoid cropping and filling spaces with white color:

| Before | After |
| - | - |
|![image](https://github.com/user-attachments/assets/4304a81f-888c-447b-8866-ee1007d0dd79)|<video src="https://github.com/user-attachments/assets/4258d32a-a6e6-4c86-9895-697fddacdf49"></video>|

