### PR TITLE
[Stack] Streamline Docker setup with local

### DIFF
--- a/.manala.yaml
+++ b/.manala.yaml
@@ -20,7 +20,7 @@ project:
 system:
     nginx:
         version: 1.24
-        port: 8000
+        port: 35080
     php:
         version: 8.3
         extensions:

--- a/.manala/docker/compose.yaml
+++ b/.manala/docker/compose.yaml
@@ -11,10 +11,10 @@ services:
         build:
             context: ..
             dockerfile: docker/Dockerfile
-        image: elao:20241028151543
+        image: elao:20241118105153
         restart: always
         ports:
-            - 8000:80
+            - 35080:80
             - 8080:8080
         volumes:
             - ../..:${MANALA_DIR}

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ make up
 ```
 
 > [!Warning]
-> The site is now available at http://localhost:8000, but you need to build or serve the assets.
+> The site is now available at http://www.ela.ooo:35080, but you need to build or serve the assets.
 
 For development purposes, start a Webpack dev-server using:
 


### PR DESCRIPTION
so we have something more close to regular projects and eliminates some difference between the local setup (for PHP devs) and the Docker ones (for more punctual needs / non PHP-devs)

```shell
make setup
```

will now up the container and install deps + build assets.

```shell
make serve
```

from inside the container, will only start the required webpack dev-server for development purposes (CSS/JS).