### PR TITLE
[Blog] Fix breadcrumbs for nested subdirectories

### DIFF
--- a/templates/blog/article.html.twig
+++ b/templates/blog/article.html.twig
@@ -47,17 +47,26 @@
 
 {% block content %}
     <div class="container">
-        {# TODO:
-            This is used for crawling to work and include parent path links to the build.
-            Remove for more appropriate place if any?
+        {#
+            The following code builds a breadcrumb trail for the article.
+            `parentPaths` is an array of the path segments of the article's URL, excluding the article's title.
+            It's used to build each intermediate breadcrumb link, reflecting the directory structure.
+            The last item in the breadcrumb is the current article, so we render an empty link (#).
         #}
         {% with {
-            parentPath: article.slug|split('/')[0:-1]|join('/'),
+            parentPaths: article.slug|split('/')[0:-1],
         } %}
             {{ macros.breadcrumb([
                 { path: path('homepage'), label: 'Accueil' },
                 { path: path('blog'), label: 'Blog' },
-                { path: path('blog_articles_from_path', { path: parentPath }), label: parentPath|u.camel.title },
+                ...parentPaths|map((p, i) =>
+                    {
+                        path: path('blog_articles_from_path', {
+                            path: [...parentPaths[0:i], p]|join('/') }
+                        ),
+                        label: p|u.camel.title
+                    },
+                ),
                 { path: '#', label: article.title },
             ]) }}
         {% endwith %}

--- a/templates/blog/articlesFromPath.html.twig
+++ b/templates/blog/articlesFromPath.html.twig
@@ -5,11 +5,30 @@
 
 {% block content %}
     <div class="container">
-        {{ macros.breadcrumb([
-            { path: path('homepage'), label: 'Accueil' },
-            { path: path('blog'), label: 'Blog' },
-            { path: '#', label: path|u.camel.title  },
-        ]) }}
+        {#
+            The following code builds a breadcrumb trail for the article.
+            `parentPaths` is an array of the path segments of the article's URL, excluding the article's title.
+            It's used to build each intermediate breadcrumb link, reflecting the directory structure.
+            The last item (`lastPath`) in the breadcrumb is the current page, so we render an empty link (#).
+        #}
+        {% with {
+            parentPaths: path|split('/')[0:-1],
+            lastPath: path|split('/')|last,
+        } %}
+            {{ macros.breadcrumb([
+                { path: path('homepage'), label: 'Accueil' },
+                { path: path('blog'), label: 'Blog' },
+                ...parentPaths|map((p, i) =>
+                    {
+                        path: path('blog_articles_from_path', {
+                            path: [...parentPaths[0:i], p]|join('/') }
+                        ),
+                        label: p|u.camel.title
+                    },
+                ),
+                { path: '#', label: lastPath|u.camel.title  },
+            ]) }}
+        {% endwith %}
 
         {{ block('articles') }}
     </div>


### PR DESCRIPTION
Devrait solutionner le soucis d'articles de blog dans un sous-répertoire (plus profond que le 1er niveau).
C'est l'alternative la plus complexe: chaque sous niveau devient une entrée du breadcrumb spécifique, et une telle arborescence créée alors une page de référence supplémentaire.

Par ex, pour : https://www.elao.com/blog/elao/alternants/accompagnement-alternants-episode-1
une page:
- `/blog/elao` (existante)
- une nouvelle page `/blog/elao/alternants` ne listant que les article du sous-répertoire `elao/alternants` apparaît.
Résultant en : `Accueil / Blog Elao / Alternants / [Épisode 1/5] Panique ! Nos alternant·e·s ont été lâché·e·s en eau libre`

![image](https://github.com/user-attachments/assets/2568f9f5-1ee0-4484-b152-ffa26edfbaae)


A voir si c'est ce que l'on souhaite, ou si l'on préfère opter pour ne conserver qu'un seul niveau.
Dans ce dernier cas, le fil d'ariane devient : 

```diff
- Accueil / Blog Elao / Alternants / [Épisode 1/5] Panique ! Nos alternant·e·s ont été lâché·e·s en eau libre
+ Accueil / Blog Elao / Alternants - [Épisode 1/5] Panique ! Nos alternant·e·s ont été lâché·e·s en eau libre
```