### PR TITLE
[Blog] Article "Les temps ritualisés chez Elao : quand le dialogue devient une culture"

### DIFF
--- a/content/blog/elao/temps-ritualises-dialogue-et-culture.md
+++ b/content/blog/elao/temps-ritualises-dialogue-et-culture.md
@@ -1,0 +1,56 @@
+---
+title: 'Les temps ritualisés chez Elao : quand le dialogue devient une culture'
+date: '2026-04-13'
+lastModified: ~
+description: "Entretiens de cycles, 1 to 1 RH, rétrospectives, baromètre interne… Découvrez les temps ritualisés qui rythment la vie chez Elao et font du dialogue une véritable culture d'entreprise."
+authors: [ mzelboch, ogandillon ]
+tableOfContent: false
+tags: [ rh, dialogue, organisation ]
+thumbnail: content/images/blog/2026/rh-rituals/rh-rituals.jpg
+---
+
+Chez Elao, on croit fermement qu'une équipe qui va bien, c'est une équipe qui performe. Et pour qu'une équipe aille bien, encore faut-il lui donner les espaces pour s'exprimer, être écoutée et accompagnée. C'est tout le sens de ce qu'on appelle nos **temps ritualisés** : des moments réguliers, structurés, dédiés à l'échange entre collaborateurs, RH et direction.
+
+Voici un tour d'horizon de ces rendez-vous qui rythment la vie chez Elao et contribuent à être dans l'échange et l'optimisation, ensemble.
+
+## Les entretiens de cycles : on fait le point tous les 6 mois
+
+Chez Elao, les entretiens annuels d'évaluation se tiennent deux fois par an. Pourquoi cette fréquence ? Parce qu'un an, c'est long. Trop long pour attendre avant de parler des difficultés du quotidien, de célébrer les réussites, qu'elles soient techniques ou personnelles, ou encore d'ajuster le cap.
+
+Ces entretiens sont des moments tri-partites, réunissant direction, RH et collaborateur. On y aborde le **bien-être au travail**, les obstacles rencontrés, les succès marquants et on y valide ensemble le prochain [cycle de travail](/blog/cycles-de-travail-et-flexibilite). Un **espace de dialogue privilégié**, au service de l'épanouissement de chacun.
+
+## Les 1 to 1 RH : un espace libre, sans agenda imposé
+
+Chaque collaborateur peut, à tout moment, solliciter un échange individuel avec [Océane](../../member/ogandillon.yaml), notre RH. Il suffit de réserver un créneau dans son planning.
+
+Ces rendez-vous sont volontairement ouverts : on peut y parler d'organisation du travail, de difficultés professionnelles mais aussi de situations personnelles ayant un impact sur le quotidien. Parfois, il s'agit simplement de "vider son sac" pour repartir plus léger. Et ça peut aussi être le point de départ d'un vrai plan d'action. Dans tous les cas, c'est un **espace de confiance**, sans jugement.
+
+## L'entretien de parcours professionnel : penser sa carrière sur le long terme
+
+Anciennement appelé "entretien professionnel", cet échange prend chez Elao une dimension plus large : il s'agit d'accompagner chaque collaborateur tout au long de sa carrière au sein de l'entreprise. **Maintenir son employabilité**, ouvrir des perspectives, permettre un vrai tournant si l'envie s'en fait sentir. Parce qu'évoluer, ce n'est pas seulement monter en grade, c'est aussi prendre des directions nouvelles et permettre à chacun d'assurer son évolution, son épanouissement chez Elao et même après.
+
+## Le point mensuel _Actu Sociale_ : la nouveauté du 1er semestre 2026
+
+Une fois par mois, un temps est désormais dédié à l'actualité sociale et juridique. L'idée ? Informer les collaborateurs, **en toute transparence**, des changements majeurs en matière de droit du travail.
+
+Parce qu'il nous semble important que chacun comprenne l'environnement légal dans lequel il évolue et que l'opacité n'a pas sa place dans notre façon de fonctionner.
+
+Par exemple, le nouveau congé parental (parce qu'on a des jeunes ou futurs papas chez Elao), qui ajoute jusqu'à 2 mois de plus pour l'un ou l'autre parent.
+
+## Les rétros semestrielles : la parole à toute l'équipe
+
+Deux fois par an, l'équipe au grand complet se réunit pour une rétrospective. Au programme : conditions de travail, projets internes, tout ce qui impacte la vie collective chez Elao en dehors de la technique.
+
+C'est un espace de dialogue supplémentaire qui nous permet de faire vivre les sujets du quotidien, grandir ensemble et de construire avec chaque membre de l'équipe une organisation qui nous ressemble.
+
+## Notre baromètre interne : prendre la température deux fois par an
+
+Tous les 6 mois, les collaborateurs sont invités à répondre à notre enquête anonyme "Et vous, comment ça va ?". Un outil simple, mais précieux, pour mesurer le bien-être des équipes et identifier les signaux (même faibles) à ne pas laisser passer.
+
+**L'anonymat** est une condition essentielle : il garantit la sincérité des réponses et nous permet d'agir là où c'est vraiment nécessaire.
+
+À l'issue, nous partageons les actions éventuelles prévues voire les co-construisons avec les équipes s'il y a un sujet à traiter.
+
+## En résumé
+
+Ces temps ritualisés ne sont pas des cases à cocher. Ce sont des **engagements concrets**, des temps indispensables que nous avons mis en place avec le collectif. Ils témoignent de la conviction qu'Elao partage depuis le début : **prendre soin des gens, c'est prendre soin du projet commun** et avancer ensemble.


### PR DESCRIPTION
## Preview
https://elao.github.io/elao_/pr/681/blog/elao/temps-ritualises-dialogue-et-culture/

## Summary
- Ajout de l'article "Les temps ritualisés chez Elao : quand le dialogue devient une culture"
- Publication prévue le 13/04/2026
- Photo d'illustration ajoutée dans `content/images/blog/2026/rh-rituals/`