### PR TITLE
[A11y] Noms accessibles : icônes décoratives, textes alternatifs, contrôles sans nom

### DIFF
--- a/assets/js/controllers/carousel_controller.js
+++ b/assets/js/controllers/carousel_controller.js
@@ -66,12 +66,21 @@ export default class extends Controller {
 
         this.dotsContainer = document.createElement('div');
         this.dotsContainer.classList.add('carousel__dots');
+        // Groupe nommé : sans ça, les puces sont annoncées isolément, sans dire à quoi
+        // elles servent.
+        this.dotsContainer.setAttribute('role', 'group');
+        this.dotsContainer.setAttribute('aria-label', 'Pagination du carrousel');
         const totalDots = Math.ceil((this.totalSlides - this.slidesToShowValue) / this.slidesToScrollValue) + 1;
 
         for (let i = 0; i < totalDots; i++) {
             const dot = document.createElement('button');
             dot.classList.add('carousel__dot');
             dot.dataset.index = i * this.slidesToScrollValue;
+            // `<button>` sans contenu : aucun nom accessible, la puce était annoncée
+            // « bouton » et rien d'autre (WCAG 4.1.2). `type` explicite pour éviter un
+            // envoi de formulaire si le carrousel est un jour imbriqué dans un `<form>`.
+            dot.type = 'button';
+            dot.setAttribute('aria-label', `Aller à la vue ${i + 1} sur ${totalDots}`);
             dot.addEventListener('click', () => this.goToSlide(i * this.slidesToScrollValue));
             this.dotsContainer.appendChild(dot);
         }
@@ -82,7 +91,15 @@ export default class extends Controller {
 
     updateDots() {
         this.dotsContainer.querySelectorAll('.carousel__dot').forEach((dot, i) => {
-            dot.classList.toggle('active', i * this.slidesToScrollValue === this.index);
+            const current = i * this.slidesToScrollValue === this.index;
+            dot.classList.toggle('active', current);
+            // La puce active n'était signalée que par une classe CSS, donc uniquement
+            // à l'œil. `aria-current` porte la même information aux lecteurs d'écran.
+            if (current) {
+                dot.setAttribute('aria-current', 'true');
+            } else {
+                dot.removeAttribute('aria-current');
+            }
         });
     }
 

--- a/assets/scss/components/_footer.scss
+++ b/assets/scss/components/_footer.scss
@@ -72,8 +72,23 @@
   border-top: solid 3px $color-secondary;
 
   span,
-  a {
+  a,
+  .see-trigger {
     margin: 0 30px;
+  }
+
+  // Le déclencheur de l'easter egg est passé de `<a>` à `<button>` pour porter un
+  // nom accessible : on neutralise les styles natifs du bouton pour conserver le
+  // rendu d'origine. Pas d'`outline: none` ici, l'anneau de focus doit rester.
+  .see-trigger {
+    padding: 0;
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    color: inherit;
+    background: none;
+    border: none;
+    cursor: pointer;
   }
 }
 
@@ -131,7 +146,8 @@
     flex-direction: column;
 
     span,
-    a {
+    a,
+    .see-trigger {
       margin: 0 0 10px;
     }
   }

--- a/src/Emoji/ElaomojiParser.php
+++ b/src/Emoji/ElaomojiParser.php
@@ -32,7 +32,7 @@ class ElaomojiParser
 
         $content = preg_replace_callback(
             '/(:[a-z0-9\+\-]+:)/',
-            fn (array $matches) => isset($emojis[$matches[1]]) ? $this->img($emojis[$matches[1]], trim($matches[1], ':')) : $matches[0],
+            fn (array $matches) => isset($emojis[$matches[1]]) ? $this->img($emojis[$matches[1]], $matches[1]) : $matches[0],
             $content,
         );
 
@@ -43,12 +43,26 @@ class ElaomojiParser
         return $content;
     }
 
-    private function img(string $path, string $alt): string
+    private function img(string $path, string $code): string
     {
         return sprintf(
             '<img class="emoji" src="%s" alt="%s">',
             $this->packages->getUrl('build/images/elaomojis/' . $path),
-            $alt,
+            htmlspecialchars($this->altFromCode($code), \ENT_QUOTES),
         );
+    }
+
+    /**
+     * Construit un texte alternatif lisible à partir du code de l'émoji.
+     *
+     * `:amelie-happy:` devenait `alt="amelie-happy"` : un slug, lu tel quel par les
+     * lecteurs d'écran. Faute de libellé rédigé dans `content/misc/elaomojis.yaml`
+     * (les 86 entrées n'ont que `code` et `path`), on humanise le code et on le
+     * préfixe pour signaler la nature de l'image. Reste une approximation : de vrais
+     * libellés éditoriaux feraient mieux.
+     */
+    private function altFromCode(string $code): string
+    {
+        return 'Elaomoji ' . str_replace('-', ' ', trim($code, ':'));
     }
 }

--- a/templates/glossary/term_list.html.twig
+++ b/templates/glossary/term_list.html.twig
@@ -3,13 +3,16 @@
         {% set term = content_get('App\\Model\\Glossary\\Term', slug) %}
         <li>
             {% if term.show %}
+                {# `alt=""` : le logo est redondant avec `term.name` juste à côté, dans
+                   le même lien. L'`alt` précédent exposait le chemin du fichier
+                   (« Logo build/images/technos/symfony.svg »), lu tel quel à voix haute. #}
                 <a href="{{ path('glossary_term', { term: term.slug })}}" class="{{ item_class|default('technologies__item') }}">
-                    <img src="{{ asset(term.logo ?? "build/images/technos/default.svg") }}" alt="Logo {{ term.logo }}">
+                    <img src="{{ asset(term.logo ?? "build/images/technos/default.svg") }}" alt="">
                     {{ term.name }}
                 </a>
             {% else %}
                 <div class="{{ item_class|default('technologies__item') }}">
-                    <img src="{{ asset(term.logo ?? "build/images/technos/default.svg") }}" alt="Logo {{ term.logo }}">
+                    <img src="{{ asset(term.logo ?? "build/images/technos/default.svg") }}" alt="">
                     {{ term.name }}
                 </div>
             {% endif %}

--- a/templates/partials/brick-contact.html.twig
+++ b/templates/partials/brick-contact.html.twig
@@ -1,11 +1,11 @@
 <div class="brick-contact" data-aos="zoom-in-up" data-aos-delay="150">
     <h3 class="title">Nous contacter</h3>
     <address>
-        <i class="icon icon--phone"></i>
+        <i class="icon icon--phone" aria-hidden="true"></i>
         <a href="tel:{{ site.contact.phone }}">{{ site.contact.phone }}</a>
     </address>
     <address>
-        <i class="icon icon--write"></i>
+        <i class="icon icon--write" aria-hidden="true"></i>
         <a href="mailto:{{ site.contact.email }}">{{ site.contact.email }}</a>
     </address>
 </div>

--- a/templates/partials/brick-visit.html.twig
+++ b/templates/partials/brick-visit.html.twig
@@ -1,7 +1,7 @@
 <div class="brick-visit" data-aos="zoom-in-up" data-aos-delay="150">
     <h3 class="title">Venir nous voir</h3>
     <address class="address">
-        <i class="icon icon--location"></i>
+        <i class="icon icon--location" aria-hidden="true"></i>
         <a class="address__content" href="{{ site.contact.address.google_maps }}" target="_blank">
             <span>34 rue Jean Broquin</span>
             <span>69006 Lyon</span>

--- a/templates/partials/footer.html.twig
+++ b/templates/partials/footer.html.twig
@@ -34,25 +34,25 @@
                 <ul>
                     <li>
                         <a href="{{ site.social.linkedin }}" target="_blank">
-                            <i class="icon icon--linkedin"></i>
+                            <i class="icon icon--linkedin" aria-hidden="true"></i>
                             Linkedin
                         </a>
                     </li>
                     <li>
                         <a href="{{ site.social.bluesky }}" target="_blank">
-                            <i class="icon icon--bluesky"></i>
+                            <i class="icon icon--bluesky" aria-hidden="true"></i>
                             Bluesky
                         </a>
                     </li>
                     <li>
                         <a href="{{ site.social.twitter }}" target="_blank">
-                            <i class="icon icon--x"></i>
+                            <i class="icon icon--x" aria-hidden="true"></i>
                             X
                         </a>
                     </li>
                     <li>
                         <a href="{{ site.social.github }}" target="_blank">
-                            <i class="icon icon--github"></i>
+                            <i class="icon icon--github" aria-hidden="true"></i>
                             Github
                         </a>
                     </li>

--- a/templates/partials/footer.html.twig
+++ b/templates/partials/footer.html.twig
@@ -79,7 +79,13 @@
             <span>© 2005 - {{ 'now'|date('Y') }} - ELAO - Tous droits réservés</span>
             <a href="{{ path('legal') }}">Mentions légales</a>
             <a href="{{ path('privacy') }}">Protection des données</a>
-            <a id="see" href="#ssss">🐍</a>
+            {# `<button>` et non `<a>` : ce déclencheur ouvre l'easter egg via JS
+               (`app.js`, `getElementById('see')`), il ne mène nulle part — `#ssss`
+               n'existe pas. Le nom accessible est obligatoire sur un contrôle
+               focalisable (WCAG 4.1.2) ; l'émoji seul n'en fournit pas. #}
+            <button type="button" id="see" class="see-trigger" aria-label="Easter egg : lancer le jeu">
+                <span aria-hidden="true">🐍</span>
+            </button>
         </section>
     </div>
 </footer>

--- a/templates/site/approach/methodology.html.twig
+++ b/templates/site/approach/methodology.html.twig
@@ -58,19 +58,19 @@
                         <div>
                             <div class="step">
                                 <div class="step__title">
-                                    <h4><i class="icon icon--team"></i>Ateliers de compréhension</h4>
+                                    <h4><i class="icon icon--team" aria-hidden="true"></i>Ateliers de compréhension</h4>
                                 </div>
                                 <p>Des ateliers de compréhension du besoin en présence de toute l’équipe technique, aboutissant à la création du <strong><a href="{{ path('glossary_term', {term: 'backlog'}) }}">backlog</a></strong> (liste des fonctionnalités envisagées sur le projet) et à une <strong>première phase de priorisation fonctionnelle</strong> (découpage en itérations).</p>
                             </div>
                             <div class="step">
                                 <div class="step__title">
-                                    <h4><i class="icon icon--mockup"></i>Ateliers UX/UI</h4>
+                                    <h4><i class="icon icon--mockup" aria-hidden="true"></i>Ateliers UX/UI</h4>
                                 </div>
                                 <p>Des atelier(s) de suivi <strong><a href="{{ path('glossary_term', {term: 'ui-ux'}) }}">UX/UI</a></strong> permettant la synchronisation de toutes les parties prenantes (fonctionnel, design, développement) avec l’objectif d’avoir des maquettes cohérentes pour toute la chaîne.</p>
                             </div>
                             <div class="step">
                                 <div class="step__title">
-                                    <h4><i class="icon icon--code"></i>Socle technique</h4>
+                                    <h4><i class="icon icon--code" aria-hidden="true"></i>Socle technique</h4>
                                 </div>
                                 <p>La mise en place du socle technique.</p>
                             </div>
@@ -78,19 +78,19 @@
                         <div>
                             <div class="step">
                                 <div class="step__title">
-                                    <h4><i class="icon icon--write"></i>Rédactions des spécifications</h4>
+                                    <h4><i class="icon icon--write" aria-hidden="true"></i>Rédactions des spécifications</h4>
                                 </div>
                                 <p>La rédaction des spécifications, soit par le client en toute autonomie selon une trame fournie par Elao, soit par Elao, soumise à validation du client.</p>
                             </div>
                             <div class="step">
                                 <div class="step__title">
-                                    <h4><i class="icon icon--pen-ruler"></i>Outils</h4>
+                                    <h4><i class="icon icon--pen-ruler" aria-hidden="true"></i>Outils</h4>
                                 </div>
                                 <p>La mise en place des outils de pilotage/suivi.</p>
                             </div>
                             <div class="step">
                                 <div class="step__title">
-                                    <h4><i class="icon icon--architecture"></i>Estimation</h4>
+                                    <h4><i class="icon icon--architecture" aria-hidden="true"></i>Estimation</h4>
                                 </div>
                                 <p>L’estimation chiffrée la plus <strong>fine possible</strong> de chaque fonctionnalité. Nous facturons en fonction du <strong>temps passé</strong> pour assurer la transparence. Avant le développement, les estimations de chaque fonctionnalité permettent d'<strong>évaluer les coûts</strong>, mais ces chiffres peuvent <strong>évoluer</strong> en fonction des découvertes et de la compréhension du projet.</p>
                             </div>
@@ -107,9 +107,9 @@
                         <p>L’équipe étant à bord depuis le tout début du projet, elle a alors une compréhension fine du projet et peut avancer de façon efficace.</p>
                     </div>
                     <ul class="build__steps">
-                        <li><i class="icon icon--mockup"></i>L'intégration responsive HTML/CSS</li>
-                        <li><i class="icon icon--code"></i>Le développement</li>
-                        <li><i class="icon icon--audit"></i><strong><a href="{{ path('glossary_term', {term: 'recette-fonctionnelle'}) }}">La recette fonctionnelle</a></strong></li>
+                        <li><i class="icon icon--mockup" aria-hidden="true"></i>L'intégration responsive HTML/CSS</li>
+                        <li><i class="icon icon--code" aria-hidden="true"></i>Le développement</li>
+                        <li><i class="icon icon--audit" aria-hidden="true"></i><strong><a href="{{ path('glossary_term', {term: 'recette-fonctionnelle'}) }}">La recette fonctionnelle</a></strong></li>
                     </ul>
                 </div>
 
@@ -135,21 +135,21 @@
                         {% with { duration: 600, delayGap: 200, delay: 0 } %}
                         <div class="step" data-aos="fade-in" data-aos-duration="{{ duration }}" data-aos-delay="{{ delay }}">
                             <div class="step__title">
-                                <h4><i class="icon icon--time"></i>Maintenance proactive par mois</h4>
+                                <h4><i class="icon icon--time" aria-hidden="true"></i>Maintenance proactive par mois</h4>
                             </div>
                             <p>Dès que le projet est accessible aux utilisateurs, l’équipe technique sur le projet passe 1 à 2 jours par mois à faire une maintenance proactive.</p>
                         </div>
                         {% set delay = delay + delayGap %}
                         <div class="step" data-aos="fade-in" data-aos-duration="{{ duration }}" data-aos-delay="{{ delay }}">
                             <div class="step__title">
-                                <h4><i class="icon icon--backlog"></i>Analyse de vos remontées</h4>
+                                <h4><i class="icon icon--backlog" aria-hidden="true"></i>Analyse de vos remontées</h4>
                             </div>
                             <p>Suivi des nouveaux tickets remontés par le client : tri, qualification de la demande (bug, évolution) et spécifications si besoin puis estimation.</p>
                         </div>
                         {% set delay = delay + delayGap %}
                         <div class="step" data-aos="fade-in" data-aos-duration="{{ duration }}" data-aos-delay="{{ delay }}">
                             <div class="step__title">
-                                <h4><i class="icon icon--person-cog"></i>Amélioration continue fonctionnelle selon votre priorisation</h4>
+                                <h4><i class="icon icon--person-cog" aria-hidden="true"></i>Amélioration continue fonctionnelle selon votre priorisation</h4>
                             </div>
                             <p>Il est possible que la V1 n’ait pas toutes les fonctionnalités envisagées en début de projet et que vos priorités aient changé en cours de développement ou en fonction des retours utilisateurs.</p>
                         </div>

--- a/templates/site/elaomojis.html.twig
+++ b/templates/site/elaomojis.html.twig
@@ -31,9 +31,14 @@
                 <h3>{{ section.title }}</h3>
                 <ul class="elaomojis">
                     {% for emoji in section.emojis %}
-                        <li class="elaomojis__item" aria-hidden="true">
+                        {# Le `aria-hidden="true"` qui était posé ici masquait un lien
+                           focalisable : au clavier on atterrissait sur un élément que
+                           les lecteurs d'écran ne pouvaient pas annoncer (WCAG 4.1.2,
+                           règle axe `aria-hidden-focus`). Le code de l'émoji sert de
+                           nom accessible, la vignette est purement décorative. #}
+                        <li class="elaomojis__item">
                             <a href="{{ asset('build/images/elaomojis/%s'|format(emoji.path)) }}" target="_blank">
-                                <span class="img" style="background: url('{{ asset('build/images/elaomojis/%s'|format(emoji.path)) }}')"></span>
+                                <span class="img" aria-hidden="true" style="background: url('{{ asset('build/images/elaomojis/%s'|format(emoji.path)) }}')"></span>
                                 {{ emoji.code }}
                             </a>
                         </li>

--- a/templates/site/home.html.twig
+++ b/templates/site/home.html.twig
@@ -113,7 +113,7 @@
                 <p>Elao est votre <strong>partenaire facilitateur</strong> à votre écoute sur toutes les étapes de votre projet. Que vous soyez <strong>novice</strong> ou <strong>expérimenté</strong> dans la réalisation de projets web,  nous vous accompagnons en vous <strong>transmettant notre culture projet et nos bonnes pratiques</strong></p>
                 <ul class="services-home">
                     <li class="services-home__card">
-                        <i class="icon icon--bulb"></i>
+                        <i class="icon icon--bulb" aria-hidden="true"></i>
                         <h3>Concevoir : comprendre et conseiller</h3>
                         <p>Pour garantir le succès de votre projet, nous commençons par une phase essentielle de compréhension et de définition de la solution.</p>
                         <ul>
@@ -127,7 +127,7 @@
                     </li>
 
                     <li class="services-home__card">
-                        <i class="icon icon--code"></i>
+                        <i class="icon icon--code" aria-hidden="true"></i>
                         <h3>Construire : développer et mettre en ligne</h3>
                         <p>Une méthode itérative et des solutions techniques qui s'adaptent à vous et votre écosystème pour développer des applications performantes et évolutives.</p>
                         <ul>
@@ -141,7 +141,7 @@
                     </li>
 
                     <li class="services-home__card">
-                        <i class="icon icon--hosting"></i>
+                        <i class="icon icon--hosting" aria-hidden="true"></i>
                         <h3>Optimiser : consolider et évoluer</h3>
                         <p>Un accompagnement proactif pour assurer la pérennité et l'évolution de vos solutions, avec un suivi régulier et une maintenance préventive.</p>
                         <ul>
@@ -155,7 +155,7 @@
                     </li>
 
                     <li class="services-home__card">
-                        <i class="icon icon--ia"></i>
+                        <i class="icon icon--ia" aria-hidden="true"></i>
                         <h3>Inspirer : valoriser et innover</h3>
                         <p>Nous mettons notre expertise technique et notre expérience métier au service de votre projet pour le faire grandir et innover ensemble.</p>
                         <ul>

--- a/templates/site/services/hosting.html.twig
+++ b/templates/site/services/hosting.html.twig
@@ -40,7 +40,10 @@
                             </span>
                         </a>
                     </div>
-                    <img src="{{ asset('build/images/pages/hosting/logo-rix.svg') }}" alt="" class="logo-rix">
+                    {# Seul contenu de sa colonne : un `alt` vide la rendait entièrement
+                       absente aux lecteurs d'écran, alors qu'elle porte l'identité de
+                       la marque présentée dans cette section. #}
+                    <img src="{{ asset('build/images/pages/hosting/logo-rix.svg') }}" alt="Logo Rix" class="logo-rix">
                 </div>
             </div>
 

--- a/templates/team/member.html.twig
+++ b/templates/team/member.html.twig
@@ -117,8 +117,12 @@
                     </div>
                 {% endif %}
 
+                {# Émojis nus : un lecteur d'écran énonce « manette de jeu vidéo,
+                   vélo, marmite » sans jamais dire de quoi il s'agit. Le nom sur la
+                   liste fournit ce contexte. Des libellés par émoji seraient plus
+                   riches, mais demandent une rédaction côté contenu. #}
                 {% if member.emojis is not empty %}
-                    <ul class="interests" data-aos="fade-in">
+                    <ul class="interests" aria-label="Centres d'intérêt de {{ member.name }}" data-aos="fade-in">
                         {% for emoji in member.emojis %}
                             <li>{{ emoji }}</li>
                         {% endfor %}


### PR DESCRIPTION
Deuxième des 4 lots du chantier d'accessibilité RGAA (P1-3 « noms accessibles »). **Indépendant de la PR A** : aucun fichier commun, les deux peuvent être relues et fusionnées dans n'importe quel ordre.

Le fil conducteur : des éléments que les lecteurs d'écran annoncent mal, ou pas du tout.

## Ce que ça corrige

**Trois non-conformités franches**

- **Le 🐍 du footer n'avait aucun nom accessible** (WCAG 4.1.2). C'était un `<a href="#ssss">` — une ancre qui n'existe pas — alors qu'il déclenche en réalité l'easter egg via JS (`app.js`, `getElementById('see')`). Passé en `<button type="button">` avec un `aria-label`. Le JS est inchangé, le jeu se lance toujours (vérifié au navigateur) et le rendu du footer est identique.
- **Un `aria-hidden="true"` masquait des liens focalisables** sur `/elaomojis` (WCAG 4.1.2, règle axe `aria-hidden-focus`). Au clavier on atterrissait sur des éléments que les lecteurs d'écran ne pouvaient pas annoncer. Retiré du `<li>`, reporté sur la vignette décorative.
- **Les puces du carrousel étaient des `<button>` vides** : annoncées « bouton », rien d'autre. Ajout d'un `aria-label` par puce, d'un `role="group"` nommé sur le conteneur, et surtout d'`aria-current` — l'état actif n'était jusque-là signalé que par une classe CSS, donc uniquement à l'œil.

**Textes alternatifs**

- **`alt` exposant un chemin de fichier** dans le glossaire : « Logo build/images/technos/symfony.svg », lu tel quel à voix haute. Passé à `alt=""` — le nom du terme est juste à côté, dans le même lien.
- **`alt` valant un slug** pour les 86 elaomojis : `:amelie-happy:` produisait `alt="amelie-happy"`. Voir « Choix à connaître » ci-dessous.
- **Logo Rix en `alt=""`** alors qu'il est le seul contenu de sa colonne : la colonne était entièrement absente aux lecteurs d'écran.

**Contexte manquant**

- **23 des 80 `<i class="icon">` sans `aria-hidden`** : toutes accompagnées de texte, donc décoratives — vérifié une par une avant de les masquer.
- **Les émojis de centres d'intérêt** sur les fiches membres étaient énoncés « manette de jeu vidéo, vélo, marmite » sans jamais dire de quoi il s'agissait. La liste porte désormais un nom.

## Choix à connaître pour relire

**`alt` des elaomojis — une approximation assumée.** `content/misc/elaomojis.yaml` ne contient que `code` et `path` pour ses 86 entrées : aucun libellé humain n'existe. Plutôt que d'inventer 86 descriptions, le parser humanise le code et le préfixe — `:amelie-happy:` donne `alt="Elaomoji amelie happy"`. C'est nettement mieux qu'un slug brut, ça couvre les ~160 usages en prose sans rédaction, et ça ne prétend pas être une description fidèle. **Ticket à ouvrir** pour de vrais libellés éditoriaux, qui seraient la bonne solution.

**Le nom de l'easter egg dévend la mèche.** `aria-label="Easter egg : lancer le jeu"` est explicite. Un contrôle focalisable doit avoir un nom, et un nom énigmatique serait conforme mais inutile. Si l'équipe préfère préserver la surprise, un simple « Serpent » suffirait — dites-le en relecture.

**`role="group"` plutôt que le pattern ARIA carrousel complet.** Nommer les puces règle la 4.1.2 pour un coût nul. Implémenter `tablist`/`tab` demanderait la gestion clavier associée — hors périmètre, et le doc d'audit prévoit déjà de *retirer* des rôles ARIA mal implémentés ailleurs (P2-5) plutôt que d'en ajouter.

## Non fait volontairement

Les libellés par émoji, côté fiches membres comme côté elaomojis : c'est de la rédaction de contenu, pas du code. La liste d'intérêts reçoit un nom global, ce qui donne le contexte manquant sans inventer de sens à la place de l'équipe.

Découpage complet en 4 PR et backlog : `work/a11y-rgaa-audit.md` § 1 et § 9 (arrive avec la PR A).

## Tests

**Automatisé** — `npx eslint` OK, `make lint.twig` OK (52 fichiers), `php-cs-fixer` 0 fichier à corriger, `make test` OK (607 pages).

⚠️ Les cibles `make lint.php-cs-fixer` et `make lint.phpstan` **échouent en local sur PHP 8.4** (leurs binaires plafonnent à 8.3) — incompatibilité d'environnement, sans rapport avec ces changements. La CI tourne en 8.3, c'est elle qui fait foi.

**Vérifié sur le HTML généré**, sur les 607 pages du build :
- 0 `<i class="icon">` sans `aria-hidden`
- 0 `alt` contenant un chemin de fichier
- `alt="Logo Rix"` présent, `alt="Elaomoji amelie happy"` et consorts corrects
- `<ul class="interests" aria-label="Centres d'intérêt de …">` bien interpolé

**Vérifié au navigateur** — le carrousel expose `role="group"` + `aria-label`, ses 3 puces ont `type="button"` et un `aria-label` numéroté, et `aria-current` suit bien la puce active au clic. L'easter egg se lance toujours après la conversion en `<button>`, et le footer est visuellement identique (même police, même taille, mêmes marges que les liens voisins).

**Reste à valider à la main** : un passage VoiceOver sur `/elaomojis`, sur un carrousel et sur une fiche membre, pour juger la qualité des annonces plutôt que leur seule présence.
