### PR TITLE
[A11y] Plan du site et pagination identifiable

### DIFF
--- a/assets/scss/pages/_page-sitemap.scss
+++ b/assets/scss/pages/_page-sitemap.scss
@@ -1,0 +1,37 @@
+// Plan du site (WCAG 2.4.5 / RGAA 12.7).
+.sitemap {
+  margin: 40px 0 80px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 40px;
+}
+
+.sitemap__section {
+  h2 {
+    margin-bottom: 15px;
+    font-family: 'faktum bold';
+    font-size: 24px;
+    color: $color-primary;
+  }
+
+  ul {
+    padding: 0;
+    list-style: none;
+  }
+
+  li {
+    margin-bottom: 8px;
+  }
+
+  a {
+    // Les liens de plan du site sont énumérés hors prose : le soulignement est le
+    // seul indice non chromatique qui les distingue (WCAG 1.4.1).
+    text-decoration: underline;
+  }
+}
+
+@media (max-width: $screen-xs) {
+  .sitemap {
+    gap: 30px;
+  }
+}

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -138,6 +138,7 @@ html.no-js [data-aos] {
 @import "pages/_page-technology";
 @import "pages/_page-values";
 @import "pages/_page-signature";
+@import "pages/_page-sitemap";
 @import "pages/_page-jobs";
 @import "pages/_page-job-posting";
 @import "pages/page-innovation-workshop";

--- a/src/Controller/SiteController.php
+++ b/src/Controller/SiteController.php
@@ -115,4 +115,41 @@ class SiteController extends AbstractController
     {
         return $this->render('site/social.html.twig');
     }
+
+    /**
+     * Plan du site — WCAG 2.4.5 (Accès multiples) / RGAA 12.7.
+     *
+     * À ne pas confondre avec le `sitemap.xml` que Stenope génère déjà : celui-ci
+     * s'adresse aux robots, celui-là aux humains. Le critère demande un second moyen
+     * d'atteindre chaque page, en plus de la navigation principale.
+     *
+     * Les collections sont chargées avec les mêmes filtres et le même tri que leurs
+     * pages d'index respectives, pour que le plan reflète ce que l'on trouve
+     * réellement en naviguant. Les 164 articles ne sont volontairement pas listés :
+     * un plan du site donne la structure, pas un index exhaustif — on s'arrête aux
+     * 7 rubriques du blog.
+     */
+    #[Route('/plan-du-site', name: 'sitemap')]
+    public function sitemap(ContentManagerInterface $manager): Response
+    {
+        $articles = $manager->getContents(Article::class, ['date' => false]);
+
+        // Rubriques du blog déduites du premier segment de slug (`dev/mon-article`),
+        // comme le fait la route `blog_articles_from_path`.
+        $categories = [];
+        foreach ($articles as $article) {
+            $segments = explode('/', $article->slug);
+            if (\count($segments) > 1) {
+                $categories[$segments[0]] = true;
+            }
+        }
+        ksort($categories);
+
+        return $this->render('site/sitemap.html.twig', [
+            'blogCategories' => array_keys($categories),
+            'caseStudies' => $manager->getContents(CaseStudy::class, ['date' => false], ['enabled' => true]),
+            'members' => $manager->getContents(Member::class, ['name' => true], ['active' => true, 'meta' => false]),
+            'jobs' => $manager->getContents(Job::class, ['date' => false], ['active' => true]),
+        ]);
+    }
 }

--- a/templates/blog/pagination.html.twig
+++ b/templates/blog/pagination.html.twig
@@ -10,25 +10,39 @@ Requires:
 {% set routeParams = routeParams ?? {} %}
 
 {% if maxPage != 1 %}
-    <ul class="pagination">
-        <li class="pagination__item pagination__item--nav">
-            <a href="{{ previousPage == minPage ? path(minPageRoute, routeParams) : path(route, routeParams|merge({ page: previousPage })) }}">
-                <i class="icon icon--chevron-left" aria-hidden="true"></i>
-                <span class="screen-reader">Page précédente</span>
-            </a>
-        </li>
-        {% for number in 1..maxPage %}
-        <li class="pagination__item {{ page == number ? 'pagination__item--active' }}">
-            <a href="{{ number == minPage ? path(minPageRoute, routeParams) : path(route, routeParams|merge({ page: number })) }}">
-                {{ number }}
-            </a>
-        </li>
-        {% endfor %}
-        <li class="pagination__item pagination__item--nav">
-            <a href="{{ path(route, routeParams|merge({ page: nextPage })) }}">
-                <i class="icon icon--chevron-right" aria-hidden="true"></i>
-                <span class="screen-reader">Page suivante</span>
-            </a>
-        </li>
-    </ul>
+    {# `<nav>` nommée : la pagination était une simple `<ul>`, donc ni identifiable
+       comme zone de navigation ni distinguable du menu principal (RGAA 12.6). #}
+    <nav aria-label="Pagination">
+        <ul class="pagination">
+            {# Le premier et le dernier lien mènent à la page courante quand on est déjà
+               à une extrémité : `aria-disabled` le signale sans retirer le focus, ce qui
+               ferait disparaître un arrêt de tabulation en cours de navigation. #}
+            <li class="pagination__item pagination__item--nav">
+                <a href="{{ previousPage == minPage ? path(minPageRoute, routeParams) : path(route, routeParams|merge({ page: previousPage })) }}"
+                   {% if page == minPage %}aria-disabled="true"{% endif %}>
+                    <i class="icon icon--chevron-left" aria-hidden="true"></i>
+                    <span class="screen-reader">Page précédente</span>
+                </a>
+            </li>
+            {% for number in 1..maxPage %}
+                <li class="pagination__item {{ page == number ? 'pagination__item--active' }}">
+                    {# `aria-current="page"` : la page courante n'était signalée que par
+                       une classe CSS, donc uniquement à l'œil. Le libellé explicite
+                       évite par ailleurs une liste de liens nommés « 1, 2, 3 ». #}
+                    <a href="{{ number == minPage ? path(minPageRoute, routeParams) : path(route, routeParams|merge({ page: number })) }}"
+                       {% if page == number %}aria-current="page"{% endif %}
+                       aria-label="Page {{ number }}{{ page == number ? ' (page courante)' }}">
+                        {{ number }}
+                    </a>
+                </li>
+            {% endfor %}
+            <li class="pagination__item pagination__item--nav">
+                <a href="{{ path(route, routeParams|merge({ page: nextPage })) }}"
+                   {% if page == maxPage %}aria-disabled="true"{% endif %}>
+                    <i class="icon icon--chevron-right" aria-hidden="true"></i>
+                    <span class="screen-reader">Page suivante</span>
+                </a>
+            </li>
+        </ul>
+    </nav>
 {% endif %}

--- a/templates/partials/footer.html.twig
+++ b/templates/partials/footer.html.twig
@@ -77,6 +77,9 @@
 
         <section class="footer__legals">
             <span>© 2005 - {{ 'now'|date('Y') }} - ELAO - Tous droits réservés</span>
+            {# Le plan du site doit être atteignable depuis toutes les pages : c'est ce
+               qui en fait un « accès multiple » au sens de WCAG 2.4.5. #}
+            <a href="{{ path('sitemap') }}">Plan du site</a>
             <a href="{{ path('legal') }}">Mentions légales</a>
             <a href="{{ path('privacy') }}">Protection des données</a>
             <a id="see" href="#ssss">🐍</a>

--- a/templates/site/sitemap.html.twig
+++ b/templates/site/sitemap.html.twig
@@ -1,0 +1,105 @@
+{% import "macros.html.twig" as macros %}
+{% extends 'base.html.twig' %}
+
+{% block meta_title "Plan du site | Elao" %}
+{% block meta_description "Toutes les pages du site Elao, organisées par rubrique." %}
+
+{% block content %}
+    <div class="container">
+        {{ macros.breadcrumb([
+            { path: path('homepage'), label: 'Accueil' },
+            { path: '#', label: "Plan du site" },
+        ]) }}
+
+        <h1>Plan du site</h1>
+        <p>Toutes les rubriques du site, avec leurs pages. Le blog compte {{ blogCategories|length }} rubriques&nbsp;: elles mènent à l'ensemble des articles.</p>
+
+        {#
+            Chaque rubrique est une `<nav>` nommée : les lecteurs d'écran peuvent ainsi
+            sauter directement à celle qui les intéresse, au lieu de parcourir une liste
+            unique de plusieurs dizaines de liens.
+        #}
+        <div class="sitemap">
+            <nav class="sitemap__section" aria-labelledby="sitemap-services">
+                <h2 id="sitemap-services">Nos services</h2>
+                <ul>
+                    <li><a href="{{ path('services') }}">Tous nos services</a></li>
+                    <li><a href="{{ path('consulting') }}">Conseil et accompagnement</a></li>
+                    <li><a href="{{ path('application') }}">Application web et mobile</a></li>
+                    <li><a href="{{ path('hosting') }}">Hébergement</a></li>
+                    <li><a href="{{ path('ia') }}">Intelligence artificielle</a></li>
+                    <li><a href="{{ path('services_optimiser') }}">Optimiser</a></li>
+                </ul>
+            </nav>
+
+            <nav class="sitemap__section" aria-labelledby="sitemap-approach">
+                <h2 id="sitemap-approach">Notre démarche</h2>
+                <ul>
+                    <li><a href="{{ path('approach') }}">La démarche</a></li>
+                    <li><a href="{{ path('collaboration') }}">Collaboration</a></li>
+                    <li><a href="{{ path('methodology') }}">Méthodologie</a></li>
+                    <li><a href="{{ path('values') }}">Nos valeurs</a></li>
+                </ul>
+            </nav>
+
+            <nav class="sitemap__section" aria-labelledby="sitemap-case-studies">
+                <h2 id="sitemap-case-studies">Études de cas</h2>
+                <ul>
+                    <li><a href="{{ path('case_studies') }}">Toutes les études de cas</a></li>
+                    {% for caseStudy in caseStudies %}
+                        <li><a href="{{ path('case_study', { caseStudy: caseStudy.slug }) }}">{{ caseStudy.title }}</a></li>
+                    {% endfor %}
+                </ul>
+            </nav>
+
+            <nav class="sitemap__section" aria-labelledby="sitemap-blog">
+                <h2 id="sitemap-blog">Blog</h2>
+                <ul>
+                    <li><a href="{{ path('blog') }}">Tous les articles</a></li>
+                    {% for category in blogCategories %}
+                        <li><a href="{{ path('blog_articles_from_path', { path: category }) }}">{{ category|u.camel.title }}</a></li>
+                    {% endfor %}
+                    <li><a href="{{ path('blog_rss') }}">Flux RSS</a></li>
+                </ul>
+            </nav>
+
+            <nav class="sitemap__section" aria-labelledby="sitemap-team">
+                <h2 id="sitemap-team">L'équipe</h2>
+                <ul>
+                    <li><a href="{{ path('team') }}">Toute l'équipe</a></li>
+                    {% for member in members %}
+                        <li><a href="{{ path('team_member', { member: member.slug }) }}">{{ member.name }}</a></li>
+                    {% endfor %}
+                </ul>
+            </nav>
+
+            <nav class="sitemap__section" aria-labelledby="sitemap-jobs">
+                <h2 id="sitemap-jobs">Nous rejoindre</h2>
+                <ul>
+                    <li><a href="{{ path('carriere') }}">Page carrière</a></li>
+                    <li><a href="{{ path('jobs') }}">Nos offres</a></li>
+                    {% for job in jobs %}
+                        <li><a href="{{ path('job', { job: job.slug }) }}">{{ job.title|join(' ') }}</a></li>
+                    {% endfor %}
+                </ul>
+            </nav>
+
+            <nav class="sitemap__section" aria-labelledby="sitemap-resources">
+                <h2 id="sitemap-resources">Ressources</h2>
+                <ul>
+                    <li><a href="{{ path('glossary') }}">Glossaire</a></li>
+                    <li><a href="{{ path('elaomojis') }}">Elaomojis</a></li>
+                </ul>
+            </nav>
+
+            <nav class="sitemap__section" aria-labelledby="sitemap-misc">
+                <h2 id="sitemap-misc">Informations</h2>
+                <ul>
+                    <li><a href="{{ path('contact') }}">Contact</a></li>
+                    <li><a href="{{ path('legal') }}">Mentions légales</a></li>
+                    <li><a href="{{ path('privacy') }}">Protection des données</a></li>
+                </ul>
+            </nav>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
Quatrième et dernier lot du chantier d'accessibilité RGAA (P1-9 + une part de P2-5). **Indépendant des PR #690 et #691** : aucun fichier commun avec la première, un seul avec la seconde (`templates/partials/footer.html.twig`, sur des lignes distinctes). Les trois peuvent être fusionnées dans n'importe quel ordre.

## Ce que ça corrige

**Un plan du site** (WCAG 2.4.5 « Accès multiples » / RGAA 12.7). Le critère demande un **second moyen** d'atteindre chaque page, en plus de la navigation principale. Il n'en existait aucun.

À ne pas confondre avec le `sitemap.xml` que Stenope génère déjà : celui-ci s'adresse aux robots, celui-là aux humains. Les deux coexistent, la route `sitemap` était libre.

**Une pagination identifiable** (WCAG 1.3.1 / RGAA 12.6). C'était une simple `<ul>` : ni repérable comme zone de navigation, ni distinguable du menu principal. Et surtout, **la page courante n'était signalée que par une classe CSS** — donc uniquement à l'œil.

## Ce que contient le plan du site

8 rubriques, 63 liens, sur `/plan-du-site`, avec un lien depuis le pied de page — vérifié présent sur **545/545 pages** du build.

| Rubrique | Contenu |
|---|---|
| Nos services | les 6 pages services |
| Notre démarche | démarche, collaboration, méthodologie, valeurs |
| Études de cas | l'index + les 20 études |
| Blog | l'index + les 7 rubriques + le flux RSS |
| L'équipe | l'index + les 16 membres actifs |
| Nous rejoindre | page carrière + offres |
| Ressources | glossaire, elaomojis |
| Informations | contact, mentions légales, confidentialité |

**Les 164 articles ne sont volontairement pas listés.** Un plan du site donne la structure, pas un index exhaustif — on s'arrête aux 7 rubriques du blog, qui mènent à tout le reste.

**Les collections utilisent les mêmes filtres et le même tri que leurs index respectifs**, pour que le plan reflète ce qu'on trouve réellement en naviguant. C'est pourquoi « Nous rejoindre » ne liste aucune offre : les 5 sont `active: false`, et `/carriere` n'en affiche aucune non plus.

## Choix à connaître pour relire

**Une `<nav>` nommée par rubrique** plutôt qu'une liste unique de 63 liens. Les lecteurs d'écran savent lister les zones de navigation : on peut ainsi sauter directement à « Études de cas » au lieu de parcourir tout le plan.

**`aria-disabled` plutôt que retirer le lien** sur les flèches précédent/suivant en bout de pagination. Retirer le lien ferait disparaître un arrêt de tabulation en cours de navigation, ce qui déplace le focus de façon imprévisible.

**`aria-label="Page 2"` sur chaque numéro.** Sans ça, la liste des liens de la page se lit « 1, 2, 3, 4… » hors contexte.

**Les rubriques du blog gardent leur nom brut titre-casé** (`Ia`, `Methodo`, `Styleguide`), ce qui donne un `Ia` un peu disgracieux. C'est **volontairement identique au fil d'Ariane des articles** (`templates/blog/article.html.twig`, même filtre `|u.camel.title`) : corriger ici seulement créerait une incohérence. À traiter globalement si l'équipe le souhaite.

## Tests

**Automatisé** — `make lint.twig` OK (53 fichiers), `php-cs-fixer` 0 fichier à corriger, `make test` OK : **608 pages** générées contre 607 avant, soit exactement la nouvelle page.

⚠️ `make lint.php-cs-fixer` et `make lint.phpstan` **échouent en local sur PHP 8.4** (leurs binaires plafonnent à 8.3) — incompatibilité d'environnement, sans rapport avec ces changements. La CI tourne en 8.3, c'est elle qui fait foi sur le nouveau contrôleur.

**Vérifié au navigateur** :
- les 8 rubriques sont bien des `<nav>` avec un nom accessible, un seul `<h1>` sur la page
- la pagination expose `aria-label="Pagination"`, `aria-current="page"` sur la page courante, `aria-disabled` sur la flèche inactive, et un libellé explicite par numéro
- le lien du pied de page mène bien au plan

**Reste à valider à la main** : le rendu du plan sur mobile (grille en colonnes) et un passage VoiceOver pour confirmer que la navigation par zones fonctionne comme prévu.
