### PR TITLE
[A11y] Lisibilité : liens de prose, contrastes et blocs extensibles

### DIFF
--- a/assets/scss/base/_mixins.scss
+++ b/assets/scss/base/_mixins.scss
@@ -1,0 +1,24 @@
+// Premier fichier de mixins du projet. Introduit pour un besoin précis : la règle de
+// soulignement des liens de prose doit s'appliquer à l'identique sur cinq conteneurs
+// rédactionnels, et une divergence entre eux serait un défaut d'accessibilité
+// silencieux.
+
+// Souligne les liens de prose (WCAG 1.4.1 / RGAA 10.6).
+//
+// Le critère interdit que la couleur soit le seul moyen de distinguer un lien de son
+// texte environnant. Le soulignement est l'indice non chromatique attendu.
+//
+// Restreint à `p`, `li` et `td` : ce sont les contextes où un lien est noyé dans du
+// texte. Les liens isolés (boutons, cartes, listes de navigation) sont identifiables
+// par leur position et leur mise en forme, et les souligner alourdirait la page sans
+// bénéfice.
+//
+// Les liens auto-stylés sont exclus : un bouton placé dans un paragraphe ne doit pas
+// se retrouver souligné. Cf. `$self-styled-links`.
+@mixin prose-links {
+  p a#{$self-styled-links},
+  li a#{$self-styled-links},
+  td a#{$self-styled-links} {
+    text-decoration: underline;
+  }
+}

--- a/assets/scss/base/_variables.scss
+++ b/assets/scss/base/_variables.scss
@@ -9,6 +9,20 @@ $color-text: #390725;
 $color-info: #1e7695;
 $color-warning: #dbb371;
 
+// Liens qui portent déjà leurs propres couleurs (bouton, lien de marque, …).
+//
+// Les règles de lien de prose s'écrivent `.conteneur a { color: … }`, soit une
+// spécificité (0,1,1) : elles battent la classe posée sur le `<a>` lui-même, qui
+// n'est qu'en (0,1,0). Un bouton placé dans un tel conteneur se retrouve donc avec
+// la couleur de texte de la prose sur son propre fond — combinaison que personne
+// n'a prévue, et qui a déjà produit deux contrastes à 1,21:1.
+//
+// Les exclusions portent sur les classes de base (`.btn`, `.link`), toujours
+// présentes aux côtés de leurs variantes (`.btn--secondary`, `.link--brand`).
+// Chaînage de `:not()` plutôt que `:not(a, b)` : la forme à liste demande
+// Safari 16.4, le chaînage est supporté partout.
+$self-styled-links: ':not(.btn):not(.link):not(.animated-link):not(.brick-send-message)';
+
 // Breakpoints
 $screen-lg: 1280px; // desktop
 $screen-md: 1220px; // laptop

--- a/assets/scss/components/_article-content.scss
+++ b/assets/scss/components/_article-content.scss
@@ -40,11 +40,8 @@
   }
 
   // Souligne les liens de prose : la couleur ne doit pas être le seul indicateur (WCAG 1.4.1)
-  p a,
-  li a,
-  td a {
-    text-decoration: underline;
-  }
+  // Mutualisé depuis, pour appliquer la même règle aux autres contenus rédactionnels.
+  @include prose-links;
 
   // Appels de notes : `line-height: 0` évite que l'exposant élargisse l'interlignage.
   // Pas de `position: relative` ici : cela créerait un bloc conteneur pour le

--- a/assets/scss/components/_brick.scss
+++ b/assets/scss/components/_brick.scss
@@ -17,11 +17,10 @@
   color: #fff;
   border: none;
 
-  // `:not(.btn)` : cette règle (0,1,1) battait `.btn--secondary` (0,1,0), qui
-  // change pourtant fond ET texte ensemble. Le bouton se retrouvait en blanc sur
-  // son fond rose pâle d'origine — 1,21:1, illisible (WCAG 1.4.3). Les boutons
-  // portent déjà leurs propres couleurs, ils n'ont pas besoin de cette surcharge.
-  a:not(.btn) {
+  // Cette règle (0,1,1) battait `.btn--secondary` (0,1,0), qui change pourtant fond
+  // ET texte ensemble : le bouton se retrouvait en blanc sur son fond rose pâle
+  // d'origine — 1,21:1, illisible (WCAG 1.4.3). Cf. `$self-styled-links`.
+  a#{$self-styled-links} {
     color: #fff;
   }
 }

--- a/assets/scss/components/_category-switch.scss
+++ b/assets/scss/components/_category-switch.scss
@@ -92,6 +92,23 @@
           }
         }
 
+        // Deux des quatre tuiles échouaient en blanc (WCAG 1.4.3, seuil 4,5:1 pour du
+        // texte de 20px) : `$color-light` donnait 1,98:1 et `$color-brand` 3,42:1.
+        // `$color-text` est le token de la charte qui passe sur les deux — 8,62:1 et
+        // 4,99:1. Les tuiles `$color-primary` (9,63:1) et `$color-info` (5,15:1)
+        // gardent le blanc.
+        &:first-child,
+        &:nth-child(3) {
+          p, span {
+            color: $color-text;
+          }
+
+          svg path {
+            fill: $color-text;
+            stroke: $color-text;
+          }
+        }
+
         &:before, &:after {
           background-color: transparent;
           content: "";

--- a/assets/scss/components/_contact.scss
+++ b/assets/scss/components/_contact.scss
@@ -121,8 +121,12 @@
     flex-direction: column;
   }
 
+  // Le bloc est en `$color-primary`, ses liens en `$color-info` (`generic/_a.scss`) :
+  // sans soulignement, rien d'autre que la teinte ne distingue l'adresse cliquable du
+  // nom « elao » qui la précède — échec WCAG 1.4.1 / RGAA 10.6.
   a {
     border: none;
+    text-decoration: underline;
   }
 
   .name {

--- a/assets/scss/components/_member.scss
+++ b/assets/scss/components/_member.scss
@@ -22,6 +22,8 @@
   }
 
   .description {
+    @include prose-links;
+
     margin-bottom: 50px;
     display: block;
   }

--- a/assets/scss/pages/_page-carriere.scss
+++ b/assets/scss/pages/_page-carriere.scss
@@ -341,7 +341,7 @@
       margin-bottom: 70px;
     }
 
-    a {
+    a#{$self-styled-links} {
       color: #FFF;
       font-weight: bold;
       text-decoration: underline;

--- a/assets/scss/pages/_page-job-posting.scss
+++ b/assets/scss/pages/_page-job-posting.scss
@@ -1,6 +1,8 @@
 .page-job-posting {}
 
 .page-job-posting__content {
+  @include prose-links;
+
   padding-left: 200px;
 
   p {

--- a/assets/scss/pages/_page-methodology.scss
+++ b/assets/scss/pages/_page-methodology.scss
@@ -81,7 +81,7 @@
         position: relative;
         color: $color-secondary;
 
-        a {
+        a#{$self-styled-links} {
           color: $color-secondary;
           text-decoration: underline;
 
@@ -151,7 +151,7 @@
             display: none;
           }
 
-          a {
+          a#{$self-styled-links} {
             color: #fff;
             text-decoration: underline;
             transition: color ease-in .1s;

--- a/assets/scss/pages/_page-project.scss
+++ b/assets/scss/pages/_page-project.scss
@@ -11,6 +11,8 @@
 }
 
 .page-project__content {
+  @include prose-links;
+
   margin-left: auto;
   max-width: calc(100% - 200px);
 

--- a/assets/scss/pages/_page-services.scss
+++ b/assets/scss/pages/_page-services.scss
@@ -291,7 +291,7 @@
       li {
         font-size: 17px;
 
-        a {
+        a#{$self-styled-links} {
           color: #fff;
           text-decoration: underline;
           transition: color ease-in .1s;
@@ -334,7 +334,7 @@
         font-size: 40px;
       }
 
-      a {
+      a#{$self-styled-links} {
         color: $color-text;
         text-decoration: underline;
         transition: color ease-in .1s;

--- a/assets/scss/pages/_page-technology.scss
+++ b/assets/scss/pages/_page-technology.scss
@@ -1,4 +1,6 @@
 .page-technology {
+  @include prose-links;
+
   padding: 0 110px;
 
   .article-list {

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -11,6 +11,7 @@ html.no-js [data-aos] {
 
 // base
 @import "base/_variables";
+@import "base/_mixins";
 @import "base/_fonts";
 @import "base/_icons";
 @import "base/_layout";

--- a/templates/site/services/application.html.twig
+++ b/templates/site/services/application.html.twig
@@ -26,7 +26,7 @@
                 <i class="icon icon--square-brackets-right" aria-hidden="true"></i>
             </span>
         </div>
-        <p class="banner-se rvices__text">
+        <p class="banner-services__text">
             Le <strong>développement d'application web et mobile</strong> est l'ADN d'Elao depuis sa création il y a {{ interval.y}} ans. Notre position <strong>d'expert</strong>, notamment sur les techno que nous utilisons au quotidien, assoie notre volonté de <strong>co-concevoir</strong> avec nos clients un projet qui répond à leurs <strong>besoins</strong>, leurs <strong>challenges</strong> et leurs <strong>ambitions</strong>.
         </p>
     </div>


### PR DESCRIPTION
Troisième lot du chantier d'accessibilité RGAA (P1-4 · P1-5 partiel · P1-8).

> Rebasée sur `main` le 16/08 : #690 étant fusionnée, l'empilement n'a plus lieu d'être. Base `main`, aucun conflit.

## Le cadrage a changé, et il faut le dire

L'audit annonçait « 10 contrastes corrigeables par substitution de token ». La mesure sur le rendu réel donne **88 échecs de contraste sur la seule page `/blog`**. J'avais ensuite avancé que la cause était les règles `a` trop larges qui écrasent les composants — c'était faux aussi.

Ce que dit la mesure :

- **Les règles larges ne causent que 5 collisions** sur tout le site, pas 34. Elles sont corrigées ici.
- **Le gros des échecs vient de la palette elle-même.** Sur les 81 combinaisons de tokens, une vingtaine seulement atteint 4,5:1. `$color-brand` sur `$color-secondary` (motif omniprésent) donne **2,82:1** ; `$color-brand` sur `$color-tertiary`, **1,24:1**. Aucun rapport avec la spécificité : ce sont deux couleurs de marque incompatibles.

**Cette PR livre donc tout ce qui ne demande pas d'arbitrage design.** La refonte de la palette est le sujet **P2-1**, qui réclamait déjà un atelier — la matrice de contraste des 9 tokens est disponible pour le préparer.

## Ce que ça corrige

**1. Les règles de prose écrasaient les boutons** (WCAG 1.4.3)

Une règle `.conteneur a { color }` est en (0,1,1) ; la classe posée sur le `<a>` n'est qu'en (0,1,0). Un bouton placé dans un tel conteneur héritait donc de la couleur de la prose sur son propre fond — combinaison que personne n'a prévue. C'est ce qui a produit les deux 1,21:1 corrigés dans #690.

Recensé sur tout le build : **5 collisions réelles**, dans `.page-services`, `.page-methodology` et `.page-carriere`. L'exclusion est centralisée dans `$self-styled-links` (`base/_variables.scss`), ce qui évite cinq variantes divergentes et remplace l'exclusion ad hoc introduite dans #690.

**2. Les liens de prose n'étaient soulignés que dans les articles** (WCAG 1.4.1 / RGAA 10.6)

Le commit `e11bcddc` avait traité `.article-content`. La règle est mutualisée dans un mixin `prose-links` et appliquée aux **quatre autres conteneurs rédactionnels** : offres d'emploi, fiches glossaire, études de cas, biographies de membres.

Plus `.contact__infos` : le bloc est en `$color-primary`, ses liens en `$color-info` — **seule la teinte** distinguait l'adresse cliquable du nom « elao » qui la précède.

**3. Le sélecteur de catégories** (WCAG 1.4.3)

Deux de ses quatre tuiles affichaient du blanc sur un fond qui ne le supporte pas : `$color-light` à **1,98:1** et `$color-brand` à **3,42:1**. Elles passent à `$color-text` — 8,62:1 et 4,99:1. Les deux autres (`$color-primary` 9,63:1, `$color-info` 5,15:1) gardent le blanc.

**4. Une classe CSS coupée par une espace** — `banner-se rvices__text` dans `application.html.twig`, qui ne s'appliquait donc pas.

## Deux divergences assumées par rapport à l'audit

**`.link--brand` n'est pas souligné.** L'audit le demandait. Mesuré : ses **374 occurrences n'apparaissent jamais** dans un `<p>`, `<li>` ou `<td>` — c'est toujours un lien isolé, avec sa flèche décorative en `:before`/`:after`. Il n'y a pas de texte environnant dont le distinguer, donc pas d'échec 1.4.1. Le souligner alourdirait sans bénéfice.

**L'icône des `.admonition` reste à 1,98:1.** C'est un glyphe icomoon de 60px posé en `content` CSS sur une pastille `$color-light` : décoration pure, le sens vient du texte et de la classe de variante. 1.4.11 ne couvre que les objets graphiques nécessaires à la compréhension. Le corriger serait un choix design — il rejoint P2-1.

## Ce qui reste hors de cette PR

Les ~51 règles `&:focus` qui ne changent qu'une couleur : elles ne posent plus problème pour le focus depuis #690, qui fournit un anneau visible sur tout le site. L'indication n'est donc plus chromatique.

Et le gros morceau : **la palette**. C'est P2-1.

## Tests

`make lint.twig` OK (52 fichiers) · `make test` OK (607 pages) · build Encore OK.

⚠️ `make lint.php-cs-fixer` et `make lint.phpstan` échouent en local sur PHP 8.4 (binaires plafonnés à 8.3) — sans rapport avec ces changements, et aucun fichier PHP n'est touché ici.

**Vérifié sur le CSS compilé après rebase** : 40 sélecteurs portent l'exclusion `$self-styled-links` ; `.contact__infos a` est souligné ; les tuiles 1 et 3 du sélecteur de catégories passent bien en `#390725`, texte **et** SVG, en `:hover` comme en `.active` ; les 5 conteneurs rédactionnels sont couverts ; la classe corrigée a disparu du HTML généré.

**Compatibilité avec #695** — les appels de notes de bas d'article ont atterri dans `_article-content.scss` entre-temps. Conflit résolu en conservant les deux : le mixin remplace la règle ad hoc, et le `text-decoration: none !important` des `sup.footnote-ref` continue de gagner. Vérifié sur le CSS compilé.

**Un commit en moins qu'à l'origine** : le correctif des hauteurs figées de `.miniature-highlight` (WCAG 1.4.4) a été livré indépendamment sur `main` entre-temps. Mon commit est devenu sans objet, je l'ai retiré plutôt que de ne réécrire que des commentaires.

**Reste à valider à la main** : c'est une PR de rendu visuel. Le sélecteur de catégories est le changement le plus visible — deux de ses quatre tuiles passent d'un texte blanc à un texte foncé au survol. Puis les cinq conteneurs rédactionnels nouvellement soulignés.

