### PR TITLE
[Blog][A11y] Notes de bas d'article

### DIFF
--- a/assets/scss/components/_footnotes.scss
+++ b/assets/scss/components/_footnotes.scss
@@ -8,6 +8,14 @@
   line-height: 1.5;
 }
 
+// Le filet marque la sortie du corps de l'article : un seul, quel que soit le
+// nombre de groupes. Les suivants s'enchaînent sous leur propre titre.
+.footnotes + .footnotes {
+  margin-top: 30px;
+  padding-top: 0;
+  border-top: none;
+}
+
 .footnotes__title {
   margin: 0 0 20px;
   padding: 0;

--- a/content/blog/styleguide/example.md
+++ b/content/blog/styleguide/example.md
@@ -13,6 +13,38 @@ credits:            { name: "Jon Tyson", url: "https://unsplash.com/@jontyson" }
 tags:               ["Tag 1", "Tag 2"]
 authors:            ["adefrance","tjarrand", "cmozzati"]
 tweetId: "1369737350830583811"
+
+# Notes de bas d'article. Le rendu de ces deux groupes est visible en fin de page.
+#
+# Écriture courte, si un seul bloc suffit : une liste de notes, sans `title` ni
+# `notes:`, titrée « Notes et références » par défaut.
+#
+#footnotes:
+#  - text:   "Conventions typographiques"                     # seul champ requis
+#    url:    "https://fr.wikipedia.org/wiki/…"                # facultatif : sans lui, la note reste du texte brut
+#    source: "Wikipédia"                                      # facultatif : affiché après le texte, séparé d'un tiret
+#    key:    "typo"                                           # facultatif : autorise l'appel [^typo]
+#
+# Écriture groupée, utilisée ci-dessous : plusieurs blocs titrés.
+footnotes:
+  - title: "Sources"
+    key:   "sources"       # facultatif : autorise les appels préfixés [^sources:…]
+    notes:
+      - { key: "typo", text: "Conventions typographiques", url: "https://fr.wikipedia.org/wiki/Wikip%C3%A9dia:Conventions_typographiques", source: "Wikipédia" }
+      - { key: "rgaa", text: "Référentiel général d'amélioration de l'accessibilité", url: "https://accessibilite.numerique.gouv.fr/", source: "DINUM" }
+  - title: "Pour aller plus loin"
+    key:   "lectures"
+    notes:
+      - { key: "median", text: "« Féminiser au point médian »", url: "http://romy.tetue.net/feminiser-au-point-median" }
+      - { key: "typochef", text: "TypoChef", url: "https://twitter.com/typochef", source: "Twitter" }
+#
+# La numérotation est continue d'un groupe à l'autre : les titres découpent
+# l'affichage, ils ne renumérotent pas. Sans quoi deux exposants « [1] »
+# cohabiteraient dans l'article sans qu'on sache lequel suivre.
+#
+# Les clés survivent au réordonnancement des listes, pas les numéros.
+# Un appel qui ne correspond à aucune note est laissé tel quel dans le texte,
+# plutôt que de produire un lien vers une ancre inexistante.
 ---
 
 ## Style
@@ -78,6 +110,40 @@ proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
 !!! danger "Titre"
     Le même [composant](https://www.elao.com) dans le style "danger".
+
+### Les notes de bas d'article
+
+Les notes se déclarent dans le header de l'article et s'affichent en fin de page, sous leur titre. On les appelle depuis le texte avec `[^…]`, ce qui produit un exposant lié à la note — et un lien de retour vers le point d'appel.
+
+Quatre façons d'appeler une note, toutes rendues ici : par son numéro absolu[^1], par sa clé[^rgaa], par sa position dans un groupe[^lectures:1], ou par sa clé dans un groupe[^lectures:typochef].
+
+```md
+par son numéro absolu[^1], par sa clé[^rgaa],
+par sa position dans un groupe[^lectures:1], ou par sa clé dans un groupe[^lectures:typochef].
+```
+
+Remarquez que `[^lectures:1]` s'affiche `[3]` : la numérotation est continue d'un groupe à l'autre. Les titres découpent l'affichage, ils ne renumérotent pas — sinon deux exposants `[1]` cohabiteraient sans qu'on sache lequel suivre.
+
+Préférez les clés aux numéros : elles survivent au réordonnancement de la liste. Un appel qui ne correspond à aucune note reste affiché tel quel plutôt que de pointer vers une ancre inexistante.
+
+```yaml
+footnotes:
+  - title: "Sources"        # facultatif : « Notes et références » par défaut
+    key:   "sources"        # facultatif : autorise les appels [^sources:…]
+    notes:
+      - { key: "typo", text: "Conventions typographiques", url: "https://…", source: "Wikipédia" }
+  - title: "Pour aller plus loin"
+    key:   "lectures"
+    notes:
+      - { key: "median", text: "« Féminiser au point médian »", url: "http://…" }
+```
+
+Si un seul bloc suffit, une simple liste de notes fait l'affaire : ni `title` ni `notes:`, et le titre par défaut s'applique.
+
+```yaml
+footnotes:
+  - { text: "Conventions typographiques", url: "https://…", source: "Wikipédia" }
+```
 
 ### Les images
 

--- a/src/Model/Article.php
+++ b/src/Model/Article.php
@@ -77,11 +77,19 @@ class Article
     public ?array $credits = null;
 
     /**
-     * Notes de bas d'article, rendues par le bloc "footnotes" du template.
-     * Elles sont référencées dans le contenu par la syntaxe `[^n]`, où `n` est
-     * la position (1-indexée) de la note dans ce tableau.
+     * Notes de bas d'article, rendues par le bloc "footnotes" du template et
+     * référencées dans le contenu par la syntaxe `[^…]`.
      *
-     * @var list<array{text: string, url?: string|null, source?: string|null}>|null
+     * Le front-matter accepte soit une liste de notes — groupe unique, titré
+     * "Notes et références" — soit une liste de groupes titrés, chacun portant
+     * une clé et sa propre liste `notes`. Les deux écritures sont ramenées à la
+     * seconde par le processor, qui numérote les notes en continu.
+     *
+     * @var list<array{
+     *     title: string,
+     *     key: string|null,
+     *     notes: list<array{number: int, key: string|null, text: string, url: string|null, source: string|null}>,
+     * }>|null
      *
      * @see \App\Stenope\Processor\HtmlFootnotesProcessor
      */

--- a/src/Stenope/Processor/HtmlFootnotesProcessor.php
+++ b/src/Stenope/Processor/HtmlFootnotesProcessor.php
@@ -10,22 +10,38 @@ use Stenope\Bundle\Behaviour\ProcessorInterface;
 use Stenope\Bundle\Content;
 
 /**
- * Remplace les appels de notes `[^n]` du contenu par un exposant lié à la note
- * correspondante du bloc "footnotes", rendu en bas d'article par le template.
+ * Remplace les appels de notes `[^…]` du contenu par un exposant lié à la note
+ * correspondante, et normalise `footnotes` pour le template.
+ *
+ * Quatre formes d'appel, toutes résolues vers le même numéro :
+ *
+ *     [^1]                  1re note de l'article
+ *     [^chronologie]        note portant cette clé, quel que soit son groupe
+ *     [^sources:1]          1re note du groupe `sources`
+ *     [^sources:barometre]  note `barometre` du groupe `sources`
+ *
+ * La numérotation est continue d'un groupe à l'autre : les groupes titrent des
+ * sections d'affichage, ils ne renumérotent pas. Deux exposants « 1 » dans le
+ * même article seraient indiscernables à la lecture.
  *
  * L'intitulé du lien ne peut pas se réduire au numéro : « 1 » seul n'est pas un
  * nom accessible explicite (RGAA 6.1). On préfixe donc d'un texte réservé aux
  * technologies d'assistance plutôt que de compter sur un attribut `title`, qui
  * n'entre dans le calcul du nom accessible qu'à défaut de contenu.
  *
+ * @phpstan-type Note array{number: int, key: string|null, text: string, url: string|null, source: string|null}
+ * @phpstan-type Group array{title: string, key: string|null, notes: list<Note>}
+ *
  * @see \App\Model\Article::$footnotes
  */
 class HtmlFootnotesProcessor implements ProcessorInterface
 {
+    public const DEFAULT_TITLE = 'Notes et références';
+
     /**
-     * Un appel de note, tel qu'écrit dans le Markdown : `[^1]`.
+     * Un appel de note : `[^1]`, `[^cle]`, `[^groupe:1]` ou `[^groupe:cle]`.
      */
-    private const MARKER_PATTERN = '/\[\^(\d+)]/';
+    private const MARKER_PATTERN = '/\[\^([a-zA-Z0-9_:-]+)]/';
 
     public function __construct(
         private HtmlCrawlerManagerInterface $crawlers,
@@ -39,7 +55,16 @@ class HtmlFootnotesProcessor implements ProcessorInterface
             return;
         }
 
-        if (!isset($data[$this->property]) || !\is_array($data['footnotes'] ?? null)) {
+        if (!\is_array($data['footnotes'] ?? null) || [] === $data['footnotes']) {
+            return;
+        }
+
+        $groups = $this->normalize($data['footnotes']);
+
+        // Le template reçoit la forme canonique : titres résolus, notes numérotées.
+        $data['footnotes'] = $groups;
+
+        if ([] === $groups || !isset($data[$this->property])) {
             return;
         }
 
@@ -50,17 +75,119 @@ class HtmlFootnotesProcessor implements ProcessorInterface
             return;
         }
 
-        $total = \count($data['footnotes']);
-
         // Une même note peut être appelée plusieurs fois : seul le premier appel
         // porte l'ancre de retour, sinon l'id serait dupliqué.
         $anchored = [];
 
         foreach ($this->collectMarkerNodes($crawler->getNode(0)) as $node) {
-            $this->replaceMarkers($node, $total, $anchored);
+            $this->replaceMarkers($node, $groups, $anchored);
         }
 
         $this->crawlers->save($content, $data, $this->property);
+    }
+
+    /**
+     * Accepte deux écritures en front-matter : une liste de notes (groupe unique,
+     * titre par défaut) ou une liste de groupes titrés.
+     *
+     * @param array<mixed> $footnotes
+     *
+     * @return list<Group>
+     */
+    private function normalize(array $footnotes): array
+    {
+        $first = $footnotes[array_key_first($footnotes)] ?? null;
+        $grouped = \is_array($first) && isset($first['notes']);
+        $rawGroups = $grouped ? $footnotes : [['notes' => $footnotes]];
+
+        $groups = [];
+        $number = 0;
+
+        foreach ($rawGroups as $rawGroup) {
+            if (!\is_array($rawGroup) || !\is_array($rawGroup['notes'] ?? null)) {
+                continue;
+            }
+
+            $notes = [];
+
+            foreach ($rawGroup['notes'] as $rawNote) {
+                if (!\is_array($rawNote) || !isset($rawNote['text'])) {
+                    continue;
+                }
+
+                $notes[] = [
+                    'number' => ++$number,
+                    'key' => isset($rawNote['key']) ? (string) $rawNote['key'] : null,
+                    'text' => (string) $rawNote['text'],
+                    'url' => isset($rawNote['url']) ? (string) $rawNote['url'] : null,
+                    'source' => isset($rawNote['source']) ? (string) $rawNote['source'] : null,
+                ];
+            }
+
+            if ([] === $notes) {
+                continue;
+            }
+
+            $groups[] = [
+                'title' => isset($rawGroup['title']) ? (string) $rawGroup['title'] : self::DEFAULT_TITLE,
+                'key' => isset($rawGroup['key']) ? (string) $rawGroup['key'] : null,
+                'notes' => $notes,
+            ];
+        }
+
+        return $groups;
+    }
+
+    /**
+     * Résout un appel vers le numéro de la note visée, ou null s'il ne correspond
+     * à aucune note : un appel resté littéral vaut mieux qu'une ancre morte.
+     *
+     * @param list<Group> $groups
+     */
+    private function resolve(string $reference, array $groups): ?int
+    {
+        $parts = explode(':', $reference, 2);
+        $target = array_pop($parts);
+        $groupKey = $parts[0] ?? null;
+
+        // Sans groupe, un numéro est absolu : il désigne directement une note.
+        if (null === $groupKey && ctype_digit($target)) {
+            return $this->hasNumber((int) $target, $groups) ? (int) $target : null;
+        }
+
+        foreach ($groups as $group) {
+            if (null !== $groupKey && $group['key'] !== $groupKey) {
+                continue;
+            }
+
+            if (ctype_digit($target)) {
+                return $group['notes'][((int) $target) - 1]['number'] ?? null;
+            }
+
+            foreach ($group['notes'] as $note) {
+                if (null !== $note['key'] && $note['key'] === $target) {
+                    return $note['number'];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<Group> $groups
+     */
+    private function hasNumber(int $number, array $groups): bool
+    {
+        foreach ($groups as $group) {
+            foreach ($group['notes'] as $note) {
+                if ($note['number'] === $number) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -100,11 +227,11 @@ class HtmlFootnotesProcessor implements ProcessorInterface
 
     /**
      * Remplace le nœud texte par la même chaîne, appels de notes convertis en exposants.
-     */
-    /**
+     *
+     * @param list<Group>      $groups
      * @param array<int, true> $anchored Notes ayant déjà reçu leur ancre de retour
      */
-    private function replaceMarkers(\DOMText $node, int $total, array &$anchored): void
+    private function replaceMarkers(\DOMText $node, array $groups, array &$anchored): void
     {
         $document = $node->ownerDocument;
         $parent = $node->parentNode;
@@ -113,7 +240,7 @@ class HtmlFootnotesProcessor implements ProcessorInterface
             return;
         }
 
-        // Alterne texte / numéro capturé : les index impairs sont les appels.
+        // Alterne texte / référence capturée : les index impairs sont les appels.
         $parts = preg_split(self::MARKER_PATTERN, $node->data, -1, PREG_SPLIT_DELIM_CAPTURE);
 
         if (false === $parts) {
@@ -131,32 +258,32 @@ class HtmlFootnotesProcessor implements ProcessorInterface
                 continue;
             }
 
-            $index = (int) $part;
+            $number = $this->resolve($part, $groups);
 
             // Un appel sans note correspondante produirait une ancre morte : on le laisse tel quel.
-            if ($index < 1 || $index > $total) {
+            if (null === $number) {
                 $fragment->appendChild($document->createTextNode("[^$part]"));
 
                 continue;
             }
 
-            $fragment->appendChild($this->createReference($document, $index, !isset($anchored[$index])));
-            $anchored[$index] = true;
+            $fragment->appendChild($this->createReference($document, $number, !isset($anchored[$number])));
+            $anchored[$number] = true;
         }
 
         $parent->replaceChild($fragment, $node);
     }
 
-    private function createReference(\DOMDocument $document, int $index, bool $anchor): \DOMElement
+    private function createReference(\DOMDocument $document, int $number, bool $anchor): \DOMElement
     {
         $sup = $document->createElement('sup');
         $sup->setAttribute('class', 'footnote-ref');
 
         $link = $document->createElement('a');
-        $link->setAttribute('href', "#footnote-$index");
+        $link->setAttribute('href', "#footnote-$number");
 
         if ($anchor) {
-            $link->setAttribute('id', "footnote-ref-$index");
+            $link->setAttribute('id', "footnote-ref-$number");
         }
 
         $label = $document->createElement('span');
@@ -164,9 +291,25 @@ class HtmlFootnotesProcessor implements ProcessorInterface
         $label->appendChild($document->createTextNode('Voir la note '));
 
         $link->appendChild($label);
-        $link->appendChild($document->createTextNode("[$index]"));
+        $link->appendChild($this->createBracket($document, '['));
+        $link->appendChild($document->createTextNode((string) $number));
+        $link->appendChild($this->createBracket($document, ']'));
         $sup->appendChild($link);
 
         return $sup;
+    }
+
+    /**
+     * Les crochets sont une convention typographique : ils restent dans le HTML
+     * pour survivre au copier-coller, mais hors du nom accessible, qui doit se
+     * lire « Voir la note 1 ».
+     */
+    private function createBracket(\DOMDocument $document, string $bracket): \DOMElement
+    {
+        $span = $document->createElement('span');
+        $span->setAttribute('aria-hidden', 'true');
+        $span->appendChild($document->createTextNode($bracket));
+
+        return $span;
     }
 }

--- a/templates/blog/article.html.twig
+++ b/templates/blog/article.html.twig
@@ -178,29 +178,31 @@
 
                 {{ article.content|raw }}
                 {% block footnotes %}
-                    {% if article.footnotes %}
+                    {% for group in article.footnotes|default([]) %}
+                        {% set title_id = 'footnotes-title-' ~ loop.index %}
                         {# `h2` et non `h1` : le titre de l'article porte déjà le `h1` de la page. #}
-                        <section class="footnotes" aria-labelledby="footnotes-title">
-                            <h2 class="footnotes__title" id="footnotes-title">Notes</h2>
-                            <ol class="footnotes__list">
-                                {% for footnote in article.footnotes %}
+                        <section class="footnotes" aria-labelledby="{{ title_id }}">
+                            <h2 class="footnotes__title" id="{{ title_id }}">{{ group.title }}</h2>
+                            {# La numérotation est continue d'un groupe à l'autre, d'où `start`. #}
+                            <ol class="footnotes__list" start="{{ group.notes|first.number }}">
+                                {% for note in group.notes %}
                                     {# `tabindex` : sans lui, l'ancre ne déplacerait pas le focus sur un `li`. #}
-                                    <li class="footnotes__item" id="footnote-{{ loop.index }}" tabindex="-1">
-                                        {% if footnote.url|default %}
-                                            <a href="{{ footnote.url }}">{{ footnote.text }}</a>
+                                    <li class="footnotes__item" id="footnote-{{ note.number }}" tabindex="-1">
+                                        {% if note.url %}
+                                            <a href="{{ note.url }}">{{ note.text }}</a>
                                         {% else %}
-                                            {{ footnote.text }}
+                                            {{ note.text }}
                                         {% endif %}
-                                        {%- if footnote.source|default %} – {{ footnote.source }}{% endif %}
-                                        <a class="footnotes__backref" href="#footnote-ref-{{ loop.index }}">
-                                            <span class="screen-reader">Retour à l’appel de la note {{ loop.index }}</span>
+                                        {%- if note.source %} – {{ note.source }}{% endif %}
+                                        <a class="footnotes__backref" href="#footnote-ref-{{ note.number }}">
+                                            <span class="screen-reader">Retour à l’appel de la note {{ note.number }}</span>
                                             <span aria-hidden="true">↩</span>
                                         </a>
                                     </li>
                                 {% endfor %}
                             </ol>
                         </section>
-                    {% endif %}
+                    {% endfor %}
                 {% endblock %}
                 {% block credits %}
                     {% if article.credits %}


### PR DESCRIPTION
## Ce que ça fait

Permet de déclarer des notes dans le header d'un article et de les appeler depuis le texte. Elles s'affichent en fin de page, sous leur titre, avec un lien de retour vers le point d'appel.

Les intitulés de liens ne se réduisent pas au numéro : un lien nommé « 1 » n'est pas explicite (RGAA 6.1). L'appel annonce « Voir la note 1 », le retour « Retour à l'appel de la note 1 ».

## Exemples

Une seule liste, titrée « Notes et références » par défaut :

```yaml
footnotes:
  - text:   "Conventions typographiques"
    url:    "https://fr.wikipedia.org/wiki/…"
    source: "Wikipédia"     # facultatif
    key:    "typo"          # facultatif
```

```md
Les règles typographiques[^1] sont utiles.
Ou par clé, plus stable si on réordonne la liste : [^typo].
```

Plusieurs blocs titrés :

```yaml
footnotes:
  - title: "Sources"
    key:   "sources"
    notes:
      - { key: "rgaa", text: "RGAA", url: "https://accessibilite.numerique.gouv.fr/" }
  - title: "Pour aller plus loin"
    key:   "lectures"
    notes:
      - { key: "median", text: "Féminiser au point médian", url: "http://romy.tetue.net/…" }
```

```md
Le référentiel[^sources:rgaa] et une lecture[^lectures:1].
```

## Un point à connaître

La numérotation est continue d'un groupe à l'autre : `[^lectures:1]` désigne la 1re note de son groupe mais s'affiche `[2]`. Les titres découpent l'affichage, ils ne renumérotent pas — sinon deux exposants `[1]` cohabiteraient dans l'article sans qu'on sache lequel suivre.

Un appel qui ne correspond à aucune note reste affiché tel quel, plutôt que de pointer vers une ancre inexistante. Les `[^…]` dans du code sont laissés intacts.

## Voir le rendu

Le guide de style le démontre en vrai, avec deux groupes : `content/blog/styleguide/example.md`, visible avec `INCLUDE_SAMPLES=1`.

## À noter

Le premier commit de la fonctionnalité (`0a3eaab`) est déjà sur `main`. Cette PR porte la suite : groupes titrés, appels par clé, crochets autour de l'appel, et la doc.