### PR TITLE
[Blog] Adapte le bandeau d'article à la longueur du titre et de la description

### DIFF
--- a/assets/scss/base/_variables.scss
+++ b/assets/scss/base/_variables.scss
@@ -16,6 +16,13 @@ $screen-sm: 995px;  // tablet
 $screen-xs: 760px;  // phone
 $screen-xxs: 380px; // small phone
 
+// Bandeau d'article (page article et article mis en avant du listing) :
+// hauteur de la couverture et hauteur dont le bloc titre/description la chevauche.
+$article-banner-cover-height: 450px;
+$article-banner-overlap: 40px;
+$article-highlight-cover-height: 480px;
+$article-highlight-overlap: 110px;
+
 // Code theme
 $code-font: monospace;
 $code-background: darken(#0d3a5a, 10%);

--- a/assets/scss/components/_article-banner.scss
+++ b/assets/scss/components/_article-banner.scss
@@ -1,12 +1,24 @@
+/*
+ * Grille en deux rangées, superposées de `$article-banner-overlap` :
+ *  - rangée 1 : la couverture (au moins `$article-banner-cover-height`) et, ancrée en bas à droite,
+ *    la carte des méta-données (`.article-info`) ;
+ *  - rangée 2 : le bloc titre + description (`.article-header`), remonté sur la couverture.
+ *
+ * Les deux rangées sont dimensionnées par leur contenu : un titre ou une description longs
+ * agrandissent le bloc vers le bas sans déborder, ni sur la couverture, ni sur la suite de la page.
+ */
 .article-banner {
-  margin-bottom: 310px;
-  height: 450px;
+  margin-bottom: 50px;
   position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: minmax($article-banner-cover-height, auto) auto;
 }
 
 .article-banner__cover {
-  height: 100%;
+  grid-area: 1 / 1;
   width: 815px;
+  max-width: 100%;
   background-size: cover !important;
   background-position: center !important;
   background-repeat: no-repeat !important;
@@ -15,7 +27,6 @@
 @media (max-width: $screen-md) {
   .article-banner {
     margin-bottom: 0;
-    height: unset;
     display: flex;
     flex-direction: column;
     align-items: flex-end;

--- a/assets/scss/components/_article-header.scss
+++ b/assets/scss/components/_article-header.scss
@@ -1,10 +1,16 @@
 .article-header {
   padding: 50px 60px;
   width: 900px;
-  height: 300px;
-  position: absolute;
-  bottom: -260px;
-  right: 0;
+  // Hauteur historique du bloc, conservée comme plancher : un titre et une description courts
+  // rendent exactement comme avant, un contenu plus long agrandit le bloc vers le bas.
+  min-height: 300px;
+  // Deuxième rangée de la grille `.article-banner`, remontée pour chevaucher la couverture.
+  grid-area: 2 / 1;
+  justify-self: end;
+  max-width: 100%;
+  margin-top: -$article-banner-overlap;
+  // Référence de positionnement pour `.article-tag-list`.
+  position: relative;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -13,18 +19,31 @@
   color: #fff;
   background: $color-brand;
 
+  // Garde-fou : un mot très long (URL, nom de techno) ne doit pas déborder du bloc.
+  h1,
+  p {
+    overflow-wrap: break-word;
+  }
+
   h1 {
     margin: 0 0 20px;
     font-family: 'antikor bold';
     font-size: 32px;
     color: #fff;
   }
+
+  // La description est le dernier élément du flux (la liste de tags est en absolu) :
+  // sa marge basse déséquilibrerait le bloc, désormais dimensionné par son contenu.
+  p:last-of-type {
+    margin-bottom: 0;
+  }
 }
 
 @media (max-width: $screen-md) {
   .article-header {
     width: 100%;
-    height: unset;
+    min-height: unset;
+    margin-top: 0;
     position: relative;
     top: unset;
     bottom: unset;

--- a/assets/scss/components/_article-info.scss
+++ b/assets/scss/components/_article-info.scss
@@ -1,9 +1,13 @@
 .article-info {
   padding: 40px 60px 20px;
   width: 390px;
-  position: absolute;
-  bottom: 10px;
-  right: 120px;
+  // Ancrée en bas à droite de la couverture (première rangée de la grille `.article-banner`).
+  // Si la carte est plus haute que la couverture, c'est la rangée qui s'agrandit.
+  grid-area: 1 / 1;
+  justify-self: end;
+  align-self: end;
+  margin: 0 120px 10px 0;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
   font-family: 'antikor regular';
@@ -38,6 +42,7 @@
 @media (max-width: $screen-md) {
   .article-info {
     padding: 30px 30px 20px;
+    margin: 0;
     position: relative;
     top: -30px;
     right: 0;

--- a/assets/scss/components/_article-tag-list.scss
+++ b/assets/scss/components/_article-tag-list.scss
@@ -51,7 +51,8 @@
 
 @media (max-width: $screen-xs) {
   .article-tag-list {
-    margin: 25px 0 10px;
+    // 55px = les 25px d'origine + la marge basse de la description, neutralisée dans `.article-header`.
+    margin: 55px 0 10px;
     position: static;
     transform: none;
     width: 100%;

--- a/assets/scss/components/_miniature-highlight.scss
+++ b/assets/scss/components/_miniature-highlight.scss
@@ -1,8 +1,12 @@
 @use "sass:color";
 
+/*
+ * Même principe que `.article-banner` : la vignette et le bloc de contenu s'empilent dans le flux,
+ * ce dernier étant remonté de `$article-highlight-overlap` pour chevaucher l'image.
+ * La hauteur de l'ensemble suit donc le contenu, sans réservation d'espace en dur.
+ */
 .miniature-highlight {
   margin: 0 0 70px;
-  padding-bottom: 190px;
   width: 100%;
   position: relative;
   display: flex;
@@ -17,7 +21,7 @@
 
 .miniature-highlight__image {
   width: calc(100% - 110px);
-  height: 480px;
+  height: $article-highlight-cover-height;
   border: none;
   overflow: hidden;
 
@@ -56,9 +60,9 @@
 }
 
 .miniature-highlight__content {
-  position: absolute;
-  top: 370px;
-  right: 0;
+  margin-top: -$article-highlight-overlap;
+  align-self: flex-end;
+  max-width: 100%;
   display: flex;
   align-items: flex-start;
 
@@ -73,8 +77,8 @@
   .details {
     padding: 50px 60px;
     width: 730px;
+    // Hauteur historique conservée comme plancher : un contenu plus long agrandit le bloc.
     min-height: 300px;
-    max-height: 400px;
     background: $color-brand;
     color: #fff;
     border: none;
@@ -91,6 +95,12 @@
       background: color.adjust($color-brand, $lightness: -2%);
     }
 
+    // Garde-fou : un mot très long (URL, nom de techno) ne doit pas déborder du bloc.
+    .title,
+    p {
+      overflow-wrap: break-word;
+    }
+
     .title {
       margin: 0 0 20px;
       font-family: 'antikor bold';
@@ -98,17 +108,20 @@
       color: #fff;
       line-height: normal !important;
     }
+
+    // Cf. `.article-header` : la marge basse du dernier paragraphe déséquilibrerait le bloc.
+    p:last-of-type {
+      margin-bottom: 0;
+    }
   }
 }
 
 @media (max-width: $screen-md) {
   .miniature-highlight {
-    padding-bottom: 240px;
-
     .miniature-highlight__content {
       .details {
         width: 550px;
-        height: 350px;
+        min-height: 350px;
       }
     }
   }
@@ -125,6 +138,9 @@
 
     .miniature-highlight__content {
       width: 100%;
+      // L'image est masquée : plus de chevauchement à compenser.
+      margin-top: 0;
+      align-self: stretch;
       position: relative;
       top: unset;
       right: unset;


### PR DESCRIPTION
## Le problème

Sur la page d'un article et sur l'article mis en avant du listing du blog, le bloc rouge titre + description avait une **hauteur fixe** et une position absolue, l'espace qu'il occupait étant réservé en dur par une marge sur son parent.

Conséquence : dès qu'un titre ou une description dépassait quelques lignes, le contenu débordait du bloc (par le haut, sur la photo de couverture et la carte auteurs) et le bloc lui-même venait chevaucher la section suivante. Autrement dit, le rendu nous imposait une **limite implicite de longueur** sur les titres et les descriptions d'articles.

### Avant

| Page article | Listing du blog | Listing du blog, en tablette |
| --- | --- | --- |
| <img alt="01-avant-article-desktop" src="https://github.com/user-attachments/assets/98280765-e3cc-438a-8d83-c4bc774f0fe0" /> | <img alt="03-avant-listing-desktop" src="https://github.com/user-attachments/assets/4a529099-7e20-4009-a68c-497eb94ebd5f" /> | <img alt="05-avant-listing-tablette" src="https://github.com/user-attachments/assets/c397478b-2ff6-4827-bbd8-0306a52cdb83" /> |

Le cas tablette est le plus abîmé : la description y était en plus tronquée par un `max-height`.

## La solution

Les blocs reviennent **dans le flux** — une grille sur la page article, une colonne flex sur le listing — et sont remontés par une marge négative pour conserver exactement le chevauchement d'origine avec la photo de couverture. La hauteur du bandeau découle donc du contenu, sans espace réservé en dur.

Les hauteurs historiques (300 px / 350 px) deviennent des `min-height` : **un titre et une description courts rendent à l'identique**, un contenu plus long agrandit le bloc vers le bas, et rien d'autre ne bouge sur la page.

### Après

| Page article | Listing du blog | Listing du blog, en tablette |
| --- | --- | --- |
| <img alt="02-apres-article-desktop" src="https://github.com/user-attachments/assets/eeb39b94-e952-4d26-ae0e-d8f068810ed4" /> | <img alt="04-apres-listing-desktop" src="https://github.com/user-attachments/assets/b8225ead-c14c-44af-87c4-6512635b38b3" /> | <img alt="06-apres-listing-tablette" src="https://github.com/user-attachments/assets/8c024369-8dbb-46c0-8941-c0c5df60da20" /> |

## Vérifications

Géométrie de tous les éléments du bandeau relevée avant / après la modification, sur 4 pages (article long, article court, `/blog`, `/blog/dev`) × 7 largeurs, de 1440 à 375 px :

- plus aucun débordement, à aucune largeur ;
- articles à description courte : géométrie identique au pixel près, y compris sur un article sans sommaire ;
- l'espace entre le bloc rouge et la section suivante est désormais constant, quelle que soit la longueur de la description (il valait 70 px, 32 px, ou −30 px de chevauchement selon les cas) ;
- padding intérieur des blocs symétrique partout (50/50 en desktop).

Deux ajustements assumés, visibles à la lecture du diff :

- la marge basse du dernier paragraphe est neutralisée dans les deux blocs, sinon un bloc dimensionné par son contenu se retrouvait avec 81 px de padding en bas contre 50 en haut. Elle est compensée sur la liste de tags en mobile, seul endroit où celle-ci est dans le flux ;
- sur le listing en tablette, le bloc rouge d'un article même court débordait déjà de ~50 px en haut et en bas : il fait maintenant sa vraie hauteur, la vignette gagne donc une centaine de pixels.

## Limite restante (autre sujet)

La colonne de tags de la page article reste en position absolue et ne peut pas agrandir le bandeau. Avec 4 tags — le maximum dans le contenu actuel — il reste au minimum 22 px de marge avant le bas du bandeau, et cette marge augmente avec la longueur du titre. Au-delà de 5-6 tags elle finirait par mordre sur le sommaire, exactement comme avant cette PR.
