### PR TITLE
[Blog] Habillage des tableaux et défilement sur petit écran

### DIFF
--- a/assets/scss/generic/_table.scss
+++ b/assets/scss/generic/_table.scss
@@ -1,0 +1,97 @@
+// Tableaux de contenu, tels que produits par la syntaxe Markdown.
+//
+// L'en-tête reprend le bloc plein de la charte — aplat prune, texte blanc en
+// antikor — et le corps se contente de filets horizontaux : les colonnes d'un
+// tableau de prose se lisent par alignement, des filets verticaux ne feraient
+// que hacher la lecture.
+
+.table-scroll {
+  margin: 60px 0;
+  // Un tableau ne se laisse pas comprimer indéfiniment (cf. `min-width` des
+  // cellules) : passé cette limite, il défile dans son conteneur plutôt que
+  // de déborder de la page.
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+
+  table {
+    margin: 0;
+  }
+}
+
+table {
+  margin: 60px 0;
+  width: 100%;
+  border-collapse: collapse;
+  font-family: 'faktum regular';
+  font-size: 18px;
+  line-height: 1.5;
+  color: $color-text;
+  // Les alignements de colonne déclarés en Markdown arrivent en style inline
+  // et prennent le pas sur cette valeur par défaut.
+  text-align: left;
+}
+
+th,
+td {
+  padding: 14px 20px;
+  // Sous cette largeur, le texte se casse mot par mot et le tableau devient
+  // illisible : mieux vaut le faire défiler. Le seuil est par cellule, donc
+  // il s'additionne avec le nombre de colonnes : deux ou trois colonnes
+  // tiennent encore sur un téléphone là où cinq défilent.
+  min-width: 7ch;
+  vertical-align: top;
+}
+
+thead th {
+  font-family: 'antikor bold';
+  font-size: 16px;
+  color: #fff;
+  background: $color-primary;
+  vertical-align: bottom;
+}
+
+tbody {
+  th,
+  td {
+    border-bottom: solid 1px rgba($color-primary, .12);
+  }
+
+  th {
+    font-family: 'faktum bold';
+    text-align: left;
+  }
+
+  // L'alternance reste une aide de lecture, pas une couleur porteuse de sens :
+  // elle doit rester discrète sous les pastilles de code inline, qui ont déjà
+  // leur propre aplat rose.
+  tr:nth-child(even) {
+    background: rgba($color-primary, .04);
+  }
+
+  tr:last-child {
+    th,
+    td {
+      border-bottom: none;
+    }
+  }
+}
+
+@media (max-width: $screen-xs) {
+  .table-scroll {
+    margin: 40px 0;
+  }
+
+  table {
+    margin: 40px 0;
+    font-size: 16px;
+  }
+
+  th,
+  td {
+    padding: 12px 15px;
+  }
+
+  thead th {
+    font-size: 15px;
+  }
+}

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -128,6 +128,7 @@ html.no-js [data-aos] {
 @import "generic/_kbd";
 @import "generic/_ul";
 @import "generic/_p";
+@import "generic/_table";
 
 // pages
 @import "pages/_page-contact";

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -46,6 +46,10 @@ services:
     App\Stenope\Processor\HtmlFootnotesProcessor:
         tags: [{ name: stenope.processor, priority: -10 }]
 
+    # Wraps content tables in a scrollable container, named after the heading above them.
+    App\Stenope\Processor\HtmlTablesProcessor:
+        tags: [{ name: stenope.processor, priority: -15 }]
+
     App\Stenope\Processor\GithubEditLinkProcessor:
         $repository: '%env(APP_GITHUB_REPO)%'
         $reference: '%env(APP_GITHUB_REF)%'

--- a/content/blog/styleguide/example.md
+++ b/content/blog/styleguide/example.md
@@ -221,6 +221,34 @@ Pensez à préciser dans le markdown le langage dans lequel est votre code, si v
 </html>
 ```
 
+### Les tableaux
+
+La syntaxe Markdown suffit : une ligne de séparation sous l'en-tête, et autant de `|` que de colonnes. Les deux-points placés dans cette ligne alignent la colonne — `---:` à droite, `:---:` au centre.
+
+| Commande | Rôle | Durée |
+|---|---|---:|
+| `make install` | Dépendances | 2 min |
+| `make serve` | Serveurs de dev | 10 s |
+| `make lint` | Tous les linters | 45 s |
+
+```md
+| Commande | Rôle | Durée |
+|---|---|---:|
+| `make install` | Dépendances | 2 min |
+```
+
+Passé un certain nombre de colonnes, un tableau ne tient plus sur un téléphone : plutôt que de comprimer le texte jusqu'à le casser mot par mot, il défile horizontalement dans son propre cadre, sans emporter la page avec lui. Rien à écrire pour cela, c'est automatique.
+
+| Langage | Extension | Coloration attendue | Commande de lint | Remarque |
+|---|---|---|---|---|
+| PHP | `.php` | `php` | `make lint.php-cs-fixer` | Ruleset `@Symfony`, strict types requis |
+| Twig | `.html.twig` | `twig` | `make lint.twig` | Templates du site et du blog |
+| YAML | `.yaml` | `yaml` | `make lint.yaml` | Configuration Symfony et front-matter |
+
+Le cadre défilant est atteignable au clavier, et il s'annonce sous le titre qui précède le tableau — ici « Les tableaux ». Écrivez donc un titre parlant avant un tableau : c'est lui qui sert de nom.
+
+Un tableau reste un tableau de données : évitez de vous en servir pour mettre en page deux colonnes de texte. Et gardez les en-têtes courts, ce sont eux qui fixent la largeur des colonnes.
+
 ### Bonus
 
 Comme toujours, on essaie tant que possible de choisir des photos libres de droit et d'en créditer les auteurs. Quelques sites de photos libres de droit : [Unsplash](https://unsplash.com/) (chouchou ❤️), [Pexels](https://www.pexels.com/), etc.

--- a/src/Stenope/Processor/HtmlTablesProcessor.php
+++ b/src/Stenope/Processor/HtmlTablesProcessor.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Stenope\Processor;
+
+use Stenope\Bundle\Behaviour\HtmlCrawlerManagerInterface;
+use Stenope\Bundle\Behaviour\ProcessorInterface;
+use Stenope\Bundle\Content;
+
+/**
+ * Enveloppe les tableaux du contenu dans un conteneur défilable horizontalement,
+ * pour les écrans trop étroits pour les afficher en entier.
+ *
+ * Le conteneur ne peut pas être produit par la feuille de style : une zone qui
+ * défile doit être atteignable au clavier (RGAA 12.7, WCAG 2.1.1), donc porter
+ * un `tabindex`, et son arrêt de tabulation doit s'annoncer — un arrêt muet
+ * laisse la personne qui l'atteint sans savoir ce qu'elle vient d'atteindre.
+ * D'où le `role` et le nom accessible, emprunté au titre qui précède le tableau.
+ *
+ * Le rôle retenu est `group` et non `region` : le nom est annoncé à la prise de
+ * focus dans les deux cas, mais `region` ajouterait un point de repère par
+ * tableau à la liste des repères de la page, que l'on parcourt justement pour
+ * s'orienter entre les grandes zones du document.
+ *
+ * Limite connue : le conteneur est un arrêt de tabulation même quand le tableau
+ * tient à l'écran et n'a donc rien à faire défiler. Ne le poser qu'au besoin
+ * demanderait de mesurer le tableau après rendu, donc du JS ; c'est un arbitrage
+ * assumé en faveur d'une solution sans script.
+ */
+class HtmlTablesProcessor implements ProcessorInterface
+{
+    /**
+     * Nom de repli, pour un tableau qu'aucun titre ne précède.
+     */
+    public const DEFAULT_LABEL = 'Tableau';
+
+    public function __construct(
+        private HtmlCrawlerManagerInterface $crawlers,
+        private string $property = 'content',
+    ) {
+    }
+
+    public function __invoke(array &$data, Content $content): void
+    {
+        if (!isset($data[$this->property])) {
+            return;
+        }
+
+        $crawler = $this->crawlers->get($content, $data, $this->property);
+
+        if (null === $crawler) {
+            // Content is not valid HTML.
+            return;
+        }
+
+        $tables = $crawler->filter('table');
+
+        if (0 === $tables->count()) {
+            return;
+        }
+
+        // Les tableaux sont collectés avant d'être déplacés : insérer un
+        // conteneur dans le document modifie la DOMNodeList que l'on itère.
+        /** @var list<\DOMElement> $elements */
+        $elements = iterator_to_array($tables, false);
+
+        foreach ($elements as $element) {
+            $this->wrap($element);
+        }
+
+        $this->crawlers->save($content, $data, $this->property);
+    }
+
+    private function wrap(\DOMElement $table): void
+    {
+        $document = $table->ownerDocument;
+        $parent = $table->parentNode;
+
+        if (null === $document || null === $parent) {
+            return;
+        }
+
+        $wrapper = $document->createElement('div');
+        $wrapper->setAttribute('class', 'table-scroll');
+        $wrapper->setAttribute('tabindex', '0');
+        $wrapper->setAttribute('role', 'group');
+
+        // Le nom est recopié plutôt que référencé par `aria-labelledby` : il est
+        // extrait du titre au moment du build, donc il ne peut pas en diverger,
+        // et il ne dépend pas de l'unicité des ids de titres — deux sections
+        // homonymes dans un même article produisent aujourd'hui le même id.
+        $label = trim($this->findPrecedingHeading($table)?->textContent ?? '');
+
+        $wrapper->setAttribute('aria-label', '' !== $label ? $label : self::DEFAULT_LABEL);
+
+        $parent->replaceChild($wrapper, $table);
+        $wrapper->appendChild($table);
+    }
+
+    /**
+     * Dernier titre rencontré avant le tableau dans l'ordre du document, quel
+     * que soit son niveau : c'est celui sous lequel le tableau se lit.
+     */
+    private function findPrecedingHeading(\DOMElement $table): ?\DOMElement
+    {
+        $document = $table->ownerDocument;
+
+        if (null === $document) {
+            return null;
+        }
+
+        $headings = (new \DOMXPath($document))->query(
+            'preceding::*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6][1]',
+            $table,
+        );
+
+        if (false === $headings) {
+            return null;
+        }
+
+        $heading = $headings->item(0);
+
+        return $heading instanceof \DOMElement ? $heading : null;
+    }
+}


### PR DESCRIPTION
**Lien de Preview 👉🏻  :** https://elao.github.io/elao_/pr/700/blog/styleguide/example/#les-tableaux
## Ce que ça fait

Les tableaux Markdown des articles n'avaient aucun style : colonnes réparties au hasard, cellules sans air, en-tête indistinct du corps. Et sur téléphone, un tableau large débordait de la page.

### Avant

| Desktop | Mobile |
| --- | --- |
| <img width="1127" height="902" alt="01-avant-desktop" src="https://github.com/user-attachments/assets/7d704f69-f84b-4945-a4a6-7a3eeee4ebac" /> | <img width="401" height="866" alt="02-avant-mobile" src="https://github.com/user-attachments/assets/bcced4a8-54d7-49e8-8f17-78ecb4244366" /> |

## La solution

Les tableaux reprennent le bloc plein de la charte — aplat prune, en-tête en antikor blanc — et le corps se limite à des filets horizontaux avec une alternance discrète, qui reste lisible sous les pastilles de code inline.

Sur petit écran, un tableau large ne se comprime plus jusqu'à casser le texte mot par mot : il défile horizontalement dans son propre cadre, sans emporter la page avec lui. Deux ou trois colonnes tiennent encore sur un téléphone, cinq défilent. Rien à écrire côté rédaction, c'est automatique.

Le cadre défilant est atteignable au clavier et s'annonce sous le titre qui précède le tableau. **Un titre parlant avant un tableau devient donc utile : c'est lui qui sert de nom.**

### Après

| Desktop | Mobile | Défilement mobile |
| --- | --- | --- |
| <img width="1084" height="1300" alt="03-apres-desktop" src="https://github.com/user-attachments/assets/ce645bf7-6c83-4b06-8613-eb22e1912831" /> | <img width="397" height="1865" alt="04-apres-mobile" src="https://github.com/user-attachments/assets/d7e2b45c-6c17-4183-877a-14d77dc5a655" /> | <video src="https://github.com/user-attachments/assets/d2b39c9e-7c67-4b08-844b-8b2d451e3a80"></video> |

## Voir le rendu (local)

Le guide de style documente et démontre la syntaxe : `content/blog/styleguide/example.md`, section « Les tableaux » (_visible avec `INCLUDE_SAMPLES=1`, par défaut en dev_).
