### PR TITLE
[A11y] Images animées contrôlables (lecture/pause)

### DIFF
--- a/assets/js/controllers/animated_image_controller.js
+++ b/assets/js/controllers/animated_image_controller.js
@@ -2,47 +2,230 @@ import { Controller } from '@hotwired/stimulus';
 
 const LABEL_PAUSE = 'Mettre l’animation en pause';
 const LABEL_PLAY = 'Lancer l’animation';
+// Sans décodeur, on ne sait pas revenir sur l'image affichée : la commande arrête
+// l'animation au lieu de la suspendre, et le dit.
+const LABEL_STOP = 'Arrêter l’animation';
 
 /**
  * Commande de lecture / pause pour les images animées du contenu (WCAG 2.2.2).
  *
- * Le format GIF n'expose aucune API de lecture : on ne peut ni l'arrêter ni lire
- * sa position. La seule prise possible est de recopier l'image telle qu'elle est
- * affichée sur un canvas, puis de masquer le GIF derrière — visuellement, plus
- * rien ne bouge, ce que le critère demande.
+ * Le format GIF n'expose aucune API de lecture, et `drawImage()` sur un `<img>`
+ * animé ne rend pas l'image affichée : Chrome y recopie systématiquement la
+ * première. Geler le visuel en l'état est donc impossible tant qu'on laisse le
+ * navigateur jouer l'animation.
  *
- * Conséquence assumée : la reprise repart de la première image. Le GIF est retiré
- * du rendu pendant la pause, le navigateur est donc libre de réinitialiser sa
- * boucle. Pour un contenu illustratif, mieux vaut ça qu'un décodage qui continue
- * en arrière-plan.
+ * On reprend donc la lecture à notre compte : le GIF est décodé image par image
+ * via `ImageDecoder`, et rendu sur un canvas dont on pilote l'avancement. La
+ * pause consiste alors simplement à ne pas programmer l'image suivante — ce qui
+ * s'arrête est bien ce qui est affiché.
+ *
+ * `ImageDecoder` manque encore à certains navigateurs, Safari en tête. On y
+ * conserve le `<img>` natif et la commande fige la première image : le mouvement
+ * cesse, ce que le critère demande, mais sans reprise au point d'arrêt. Le nom du
+ * bouton change en conséquence, pour ne pas promettre une pause qui n'en est pas
+ * une.
  */
 export default class extends Controller {
-    static targets = ['image', 'toggle', 'label'];
+    static targets = ['image', 'label'];
 
     connect() {
+        this.frames = null;
+        this.index = 0;
+        this.timer = null;
         this.canvas = null;
+        this.decoder = null;
+        this.destroyed = false;
+        this.reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        this.supported = typeof window.ImageDecoder !== 'undefined';
 
-        // Une préférence système pour le mouvement réduit vaut demande explicite :
-        // on démarre en pause plutôt que d'attendre un clic. La commande reste là
-        // pour lancer l'animation à la demande.
-        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-            this._whenReady(() => this.pause());
+        if (!this.supported) {
+            this._setLabel(LABEL_STOP);
+
+            if (this.reduced) {
+                this._whenLoaded(() => this._freeze());
+            }
+
+            return;
         }
+
+        // Le décodage n'a de sens que si l'image est susceptible d'être vue :
+        // décoder d'emblée les images d'un article entier coûterait cher pour rien.
+        this.observer = new IntersectionObserver(entries => {
+            if (entries.some(e => e.isIntersecting)) {
+                this.observer.disconnect();
+                this.observer = null;
+                this._takeOver();
+            }
+        }, { rootMargin: '200px' });
+
+        this.observer.observe(this.element);
     }
 
     disconnect() {
-        this._removeCanvas();
+        this.destroyed = true;
+        this._stopTimer();
+        this.observer?.disconnect();
+        this.decoder?.close();
+        this.decoder = null;
+        this.canvas?.remove();
+        this.canvas = null;
     }
 
     toggle() {
-        if (this.canvas) {
-            this.play();
-        } else {
-            this.pause();
+        if (!this.frames) {
+            // Mode dégradé : on fige, ou on relâche le `<img>`.
+            this.canvas ? this._unfreeze() : this._freeze();
+
+            return;
         }
+
+        this.playing ? this.pause() : this.play();
     }
 
     pause() {
+        this._stopTimer();
+        this._setState(false);
+    }
+
+    play() {
+        if (!this.frames || this.playing) {
+            return;
+        }
+
+        this._setState(true);
+        this._advance();
+    }
+
+    // — Lecture pilotée ————————————————————————————————————————————————
+
+    async _takeOver() {
+        try {
+            const response = await fetch(this.imageTarget.currentSrc, { cache: 'force-cache' });
+            // eslint-disable-next-line no-undef -- WebCodecs, présence testée dans connect()
+            const decoder = new ImageDecoder({
+                data: await response.arrayBuffer(),
+                type: 'image/gif',
+            });
+
+            // Les deux attentes sont nécessaires et distinctes : `tracks.ready`
+            // renseigne la piste — sans elle `selectedTrack` reste indéfini — et
+            // `completed` garantit que `frameCount` est définitif et non le compte
+            // partiel des images déjà reçues.
+            await decoder.tracks.ready;
+            await decoder.completed;
+
+            const track = decoder.tracks.selectedTrack;
+
+            // Un GIF d'une seule image n'a rien à contrôler : on retire la commande
+            // plutôt que d'afficher un bouton sans effet.
+            if (!track || track.frameCount < 2) {
+                decoder.close();
+                this.element.classList.add('animated-image--static');
+
+                return;
+            }
+
+            if (this.destroyed) {
+                decoder.close();
+
+                return;
+            }
+
+            this.decoder = decoder;
+            this.frames = track.frameCount;
+            this._mountCanvas();
+
+            await this._render(0);
+
+            if (this.reduced) {
+                this._setState(false);
+            } else {
+                this.play();
+            }
+        } catch {
+            // Décodage impossible (réseau, format inattendu) : le `<img>` continue de
+            // jouer et la commande retombe sur le gel première image.
+            this._setLabel(LABEL_STOP);
+        }
+    }
+
+    _mountCanvas() {
+        const image = this.imageTarget;
+        const canvas = document.createElement('canvas');
+
+        canvas.width = image.naturalWidth;
+        canvas.height = image.naturalHeight;
+        canvas.className = 'animated-image__frame';
+
+        // Le canvas devient le rendu visible : il reprend l'alternative textuelle
+        // de l'image qu'il remplace, sans quoi celle-ci disparaîtrait de l'arbre
+        // d'accessibilité en même temps que le `<img>`.
+        const alt = image.getAttribute('alt') ?? '';
+
+        if (alt.trim()) {
+            canvas.setAttribute('role', 'img');
+            canvas.setAttribute('aria-label', alt);
+        } else {
+            canvas.setAttribute('aria-hidden', 'true');
+        }
+
+        image.after(canvas);
+        image.hidden = true;
+
+        this.canvas = canvas;
+        // Surtout pas `this.context` : Stimulus s'en sert pour son propre contexte,
+        // et l'écraser casse `this.element` — donc tout le contrôleur, en silence.
+        this.ctx = canvas.getContext('2d');
+    }
+
+    async _render(index) {
+        if (!this.decoder || this.destroyed) {
+            return 100;
+        }
+
+        const { image } = await this.decoder.decode({ frameIndex: index });
+
+        this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        this.ctx.drawImage(image, 0, 0);
+
+        // `duration` est en microsecondes, et peut manquer. Les navigateurs
+        // imposent un plancher de 20 ms aux GIF, on s'aligne dessus.
+        const duration = image.duration ? image.duration / 1000 : 100;
+
+        image.close();
+
+        return Math.max(duration, 20);
+    }
+
+    /**
+     * Rend l'image courante puis programme la suivante. Le décodage étant
+     * asynchrone, on revérifie l'état de lecture après l'attente : une pause
+     * demandée entre-temps ne doit pas relancer la boucle.
+     */
+    async _advance() {
+        const delay = await this._render(this.index);
+
+        if (this.destroyed || !this.playing) {
+            return;
+        }
+
+        this.timer = window.setTimeout(() => {
+            this.timer = null;
+            this.index = (this.index + 1) % this.frames;
+            this._advance();
+        }, delay);
+    }
+
+    _stopTimer() {
+        if (this.timer) {
+            window.clearTimeout(this.timer);
+            this.timer = null;
+        }
+    }
+
+    // — Mode dégradé ———————————————————————————————————————————————————
+
+    _freeze() {
         const image = this.imageTarget;
 
         if (this.canvas || !image.naturalWidth) {
@@ -50,11 +233,10 @@ export default class extends Controller {
         }
 
         const canvas = document.createElement('canvas');
+
         canvas.width = image.naturalWidth;
         canvas.height = image.naturalHeight;
         canvas.className = 'animated-image__frame';
-        // L'image porte déjà l'alternative textuelle : la dupliquer sur le canvas
-        // la ferait annoncer deux fois pendant la pause.
         canvas.setAttribute('aria-hidden', 'true');
         canvas.getContext('2d').drawImage(image, 0, 0);
 
@@ -65,32 +247,28 @@ export default class extends Controller {
         this._setState(false);
     }
 
-    play() {
-        this._removeCanvas();
+    _unfreeze() {
+        this.canvas?.remove();
+        this.canvas = null;
         this.imageTarget.hidden = false;
         this._setState(true);
     }
 
-    _removeCanvas() {
-        if (this.canvas) {
-            this.canvas.remove();
-            this.canvas = null;
-        }
-    }
+    // — Commun ——————————————————————————————————————————————————————————
 
     _setState(playing) {
+        this.playing = playing;
         this.element.classList.toggle('animated-image--paused', !playing);
+        this._setLabel(playing ? (this.frames ? LABEL_PAUSE : LABEL_STOP) : LABEL_PLAY);
+    }
 
+    _setLabel(text) {
         if (this.hasLabelTarget) {
-            this.labelTarget.textContent = playing ? LABEL_PAUSE : LABEL_PLAY;
+            this.labelTarget.textContent = text;
         }
     }
 
-    /**
-     * `naturalWidth` vaut 0 tant que l'image n'est pas décodée : sans cette
-     * attente, une mise en pause au chargement produirait un canvas vide.
-     */
-    _whenReady(callback) {
+    _whenLoaded(callback) {
         if (this.imageTarget.complete && this.imageTarget.naturalWidth) {
             callback();
         } else {

--- a/assets/js/controllers/animated_image_controller.js
+++ b/assets/js/controllers/animated_image_controller.js
@@ -1,0 +1,100 @@
+import { Controller } from '@hotwired/stimulus';
+
+const LABEL_PAUSE = 'Mettre l’animation en pause';
+const LABEL_PLAY = 'Lancer l’animation';
+
+/**
+ * Commande de lecture / pause pour les images animées du contenu (WCAG 2.2.2).
+ *
+ * Le format GIF n'expose aucune API de lecture : on ne peut ni l'arrêter ni lire
+ * sa position. La seule prise possible est de recopier l'image telle qu'elle est
+ * affichée sur un canvas, puis de masquer le GIF derrière — visuellement, plus
+ * rien ne bouge, ce que le critère demande.
+ *
+ * Conséquence assumée : la reprise repart de la première image. Le GIF est retiré
+ * du rendu pendant la pause, le navigateur est donc libre de réinitialiser sa
+ * boucle. Pour un contenu illustratif, mieux vaut ça qu'un décodage qui continue
+ * en arrière-plan.
+ */
+export default class extends Controller {
+    static targets = ['image', 'toggle', 'label'];
+
+    connect() {
+        this.canvas = null;
+
+        // Une préférence système pour le mouvement réduit vaut demande explicite :
+        // on démarre en pause plutôt que d'attendre un clic. La commande reste là
+        // pour lancer l'animation à la demande.
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+            this._whenReady(() => this.pause());
+        }
+    }
+
+    disconnect() {
+        this._removeCanvas();
+    }
+
+    toggle() {
+        if (this.canvas) {
+            this.play();
+        } else {
+            this.pause();
+        }
+    }
+
+    pause() {
+        const image = this.imageTarget;
+
+        if (this.canvas || !image.naturalWidth) {
+            return;
+        }
+
+        const canvas = document.createElement('canvas');
+        canvas.width = image.naturalWidth;
+        canvas.height = image.naturalHeight;
+        canvas.className = 'animated-image__frame';
+        // L'image porte déjà l'alternative textuelle : la dupliquer sur le canvas
+        // la ferait annoncer deux fois pendant la pause.
+        canvas.setAttribute('aria-hidden', 'true');
+        canvas.getContext('2d').drawImage(image, 0, 0);
+
+        image.after(canvas);
+        image.hidden = true;
+
+        this.canvas = canvas;
+        this._setState(false);
+    }
+
+    play() {
+        this._removeCanvas();
+        this.imageTarget.hidden = false;
+        this._setState(true);
+    }
+
+    _removeCanvas() {
+        if (this.canvas) {
+            this.canvas.remove();
+            this.canvas = null;
+        }
+    }
+
+    _setState(playing) {
+        this.element.classList.toggle('animated-image--paused', !playing);
+
+        if (this.hasLabelTarget) {
+            this.labelTarget.textContent = playing ? LABEL_PAUSE : LABEL_PLAY;
+        }
+    }
+
+    /**
+     * `naturalWidth` vaut 0 tant que l'image n'est pas décodée : sans cette
+     * attente, une mise en pause au chargement produirait un canvas vide.
+     */
+    _whenReady(callback) {
+        if (this.imageTarget.complete && this.imageTarget.naturalWidth) {
+            callback();
+        } else {
+            this.imageTarget.addEventListener('load', callback, { once: true });
+        }
+    }
+}

--- a/assets/scss/components/_animated-image.scss
+++ b/assets/scss/components/_animated-image.scss
@@ -1,0 +1,68 @@
+// Image animée du contenu, munie de sa commande de lecture / pause (WCAG 2.2.2).
+// Cf. `HtmlAnimatedImagesProcessor` et `animated_image_controller`.
+.animated-image {
+  position: relative;
+  // Le conteneur reprend la place que l'image occupait seule : `generic/_img.scss`
+  // pose `margin: 35px auto` sur les images de contenu. Laissée sur l'image, cette
+  // marge se retrouverait *à l'intérieur* du conteneur — le bouton, positionné par
+  // rapport à lui, flotterait alors au-dessus du vide plutôt que sur le visuel, et
+  // le centrage horizontal serait perdu.
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  margin: 35px auto;
+
+  img,
+  .animated-image__frame {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin: 0;
+  }
+}
+
+.animated-image__toggle {
+  // Haut-gauche de l'image, décalé vers l'intérieur pour ne pas mordre sur le
+  // bord — la cible reste ainsi entièrement sur le visuel.
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  padding: 0;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  // Fond sombre opaque plutôt que translucide : le contraste du pictogramme ne
+  // doit pas dépendre de l'image qui se trouve dessous. Blanc sur $color-dark
+  // donne 11,86:1, très au-delà des 3:1 exigés pour un élément non textuel.
+  background: $color-dark;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: transform ease-in .1s;
+
+  &:hover {
+    transform: scale(1.08);
+  }
+
+  // Pas d'`outline: none` ici : l'anneau de focus global doit rester (cf. base/_focus).
+}
+
+.animated-image__icons {
+  display: flex;
+}
+
+.animated-image__icon {
+  display: block;
+}
+
+// La permutation est portée par la classe d'état plutôt que par le JS, pour que
+// le rendu reste cohérent si le script n'a pas encore pris la main.
+.animated-image__icon--play { display: none; }
+
+.animated-image--paused {
+  .animated-image__icon--pause { display: none; }
+  .animated-image__icon--play { display: block; }
+}

--- a/assets/scss/components/_animated-image.scss
+++ b/assets/scss/components/_animated-image.scss
@@ -19,6 +19,13 @@
     height: auto;
     margin: 0;
   }
+
+  // `display: block` ci-dessus bat le `[hidden] { display: none }` de la feuille
+  // du navigateur : sans ce rappel, l'image reste affichée sous le canvas qui la
+  // remplace, et le visuel apparaît en double.
+  img[hidden] {
+    display: none;
+  }
 }
 
 .animated-image__toggle {
@@ -61,6 +68,10 @@
 // La permutation est portée par la classe d'état plutôt que par le JS, pour que
 // le rendu reste cohérent si le script n'a pas encore pris la main.
 .animated-image__icon--play { display: none; }
+
+// Une image d'une seule vue n'a rien à contrôler : le décodeur retire la commande
+// plutôt que d'afficher un bouton sans effet.
+.animated-image--static .animated-image__toggle { display: none; }
 
 .animated-image--paused {
   .animated-image__icon--pause { display: none; }

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -32,6 +32,7 @@ html.no-js [data-aos] {
 @import "components/_alert";
 @import "components/_amabla-brief-incentive";
 @import "components/_animated-block";
+@import "components/_animated-image";
 @import "components/_animated-link";
 @import "components/_article-author";
 @import "components/_article-banner";

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -50,6 +50,10 @@ services:
     App\Stenope\Processor\HtmlTablesProcessor:
         tags: [{ name: stenope.processor, priority: -15 }]
 
+    # Wraps animated GIFs in a container with a play/pause control (WCAG 2.2.2).
+    App\Stenope\Processor\HtmlAnimatedImagesProcessor:
+        tags: [{ name: stenope.processor, priority: -16 }]
+
     App\Stenope\Processor\GithubEditLinkProcessor:
         $repository: '%env(APP_GITHUB_REPO)%'
         $reference: '%env(APP_GITHUB_REF)%'

--- a/src/Stenope/Processor/HtmlAnimatedImagesProcessor.php
+++ b/src/Stenope/Processor/HtmlAnimatedImagesProcessor.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Stenope\Processor;
+
+use Stenope\Bundle\Behaviour\HtmlCrawlerManagerInterface;
+use Stenope\Bundle\Behaviour\ProcessorInterface;
+use Stenope\Bundle\Content;
+
+/**
+ * Enveloppe les images animées du contenu dans un conteneur muni d'une commande
+ * de lecture / pause.
+ *
+ * Un GIF animé démarre seul et boucle indéfiniment : il entre donc dans le champ
+ * de WCAG 2.2.2 (RGAA 13.8), qui exige un moyen de mettre en pause, arrêter ou
+ * masquer tout mouvement automatique de plus de cinq secondes. Le format n'offre
+ * aucun contrôle natif, contrairement à `<video>` — d'où cette commande ajoutée
+ * au build.
+ *
+ * Le conteneur est produit ici plutôt qu'en Twig parce que ces images viennent du
+ * markdown des articles : elles n'ont pas de gabarit où insérer un bouton.
+ *
+ * Seuls les GIF sont concernés. Les PNG et WebP animés existent mais le dépôt
+ * n'en contient aucun, et les détecter demanderait de lire l'en-tête de chaque
+ * fichier — on s'en tiendra à l'extension tant que ce n'est pas nécessaire.
+ *
+ * La mise en pause elle-même est faite côté client (`animated_image_controller`) :
+ * elle consiste à figer l'image courante sur un canvas. Rien ne peut la produire
+ * au build, puisqu'il s'agit de l'état de l'animation au moment du clic.
+ */
+class HtmlAnimatedImagesProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private HtmlCrawlerManagerInterface $crawlers,
+        private string $property = 'content',
+    ) {
+    }
+
+    public function __invoke(array &$data, Content $content): void
+    {
+        if (!isset($data[$this->property])) {
+            return;
+        }
+
+        $crawler = $this->crawlers->get($content, $data, $this->property);
+
+        if (null === $crawler) {
+            // Content is not valid HTML.
+            return;
+        }
+
+        $images = $crawler->filter('img');
+
+        if (0 === $images->count()) {
+            return;
+        }
+
+        // Les images sont collectées avant d'être déplacées : insérer un conteneur
+        // dans le document modifie la DOMNodeList que l'on itère.
+        /** @var list<\DOMElement> $elements */
+        $elements = iterator_to_array($images, false);
+
+        $wrapped = false;
+
+        foreach ($elements as $element) {
+            if ($this->isAnimated($element)) {
+                $this->wrap($element);
+                $wrapped = true;
+            }
+        }
+
+        if ($wrapped) {
+            $this->crawlers->save($content, $data, $this->property);
+        }
+    }
+
+    /**
+     * L'extension est lue sur le chemin seul : une URL de contenu peut porter une
+     * chaîne de requête (redimensionnement Glide) ou une ancre.
+     */
+    private function isAnimated(\DOMElement $image): bool
+    {
+        $src = $image->getAttribute('src');
+
+        if ('' === $src) {
+            return false;
+        }
+
+        $path = parse_url($src, \PHP_URL_PATH);
+
+        if (!\is_string($path)) {
+            return false;
+        }
+
+        return 'gif' === strtolower(pathinfo($path, \PATHINFO_EXTENSION));
+    }
+
+    private function wrap(\DOMElement $image): void
+    {
+        $document = $image->ownerDocument;
+        $parent = $image->parentNode;
+
+        if (null === $document || null === $parent) {
+            return;
+        }
+
+        $wrapper = $document->createElement('div');
+        $wrapper->setAttribute('class', 'animated-image');
+        $wrapper->setAttribute('data-controller', 'animated-image');
+
+        $parent->replaceChild($wrapper, $image);
+        $wrapper->appendChild($image);
+
+        $image->setAttribute('data-animated-image-target', 'image');
+
+        $wrapper->appendChild($this->createToggle($document));
+    }
+
+    /**
+     * Le nom accessible du bouton change avec l'état plutôt que d'être fixe et
+     * doublé d'un `aria-pressed` : les deux mécanismes ensemble se recouvrent, et
+     * « Lancer l'animation » dit à lui seul ce que fera l'activation.
+     *
+     * Les deux pictogrammes sont posés ici et permutés par la feuille de style
+     * selon l'état : le bouton reste utilisable si le JS échoue à se charger —
+     * il ne fera rien, mais il n'affichera pas non plus un état mensonger.
+     */
+    private function createToggle(\DOMDocument $document): \DOMElement
+    {
+        $button = $document->createElement('button');
+        $button->setAttribute('type', 'button');
+        $button->setAttribute('class', 'animated-image__toggle');
+        $button->setAttribute('data-animated-image-target', 'toggle');
+        $button->setAttribute('data-action', 'animated-image#toggle');
+
+        $icons = $document->createElement('span');
+        $icons->setAttribute('class', 'animated-image__icons');
+        $icons->setAttribute('aria-hidden', 'true');
+        $icons->appendChild($this->createIcon($document, 'pause'));
+        $icons->appendChild($this->createIcon($document, 'play'));
+        $button->appendChild($icons);
+
+        $label = $document->createElement('span', 'Mettre l’animation en pause');
+        $label->setAttribute('class', 'screen-reader');
+        $label->setAttribute('data-animated-image-target', 'label');
+        $button->appendChild($label);
+
+        return $button;
+    }
+
+    private function createIcon(\DOMDocument $document, string $name): \DOMElement
+    {
+        $svg = $document->createElement('svg');
+        $svg->setAttribute('class', "animated-image__icon animated-image__icon--$name");
+        $svg->setAttribute('viewBox', '0 0 24 24');
+        $svg->setAttribute('width', '18');
+        $svg->setAttribute('height', '18');
+        $svg->setAttribute('focusable', 'false');
+        $svg->setAttribute('aria-hidden', 'true');
+
+        $path = $document->createElement('path');
+        $path->setAttribute('fill', 'currentColor');
+        $path->setAttribute('d', 'pause' === $name
+            ? 'M8 5h3v14H8zm5 0h3v14h-3z'
+            : 'M8 5l11 7-11 7z');
+        $svg->appendChild($path);
+
+        return $svg;
+    }
+}


### PR DESCRIPTION
Répond au retour **« Prévoir la possibilité de contrôler les contenus en mouvement »** de la check-list RGAA (lignes 21 et 80), soit WCAG 2.2.2 / RGAA 13.8.

Indépendant de #693 : un seul fichier commun, `assets/scss/style.scss`, et sur une ligne d'import différente.

## Le problème

Un GIF animé démarre seul et boucle indéfiniment. Il entre donc dans le champ du critère, qui exige un moyen de mettre en pause, arrêter ou masquer tout mouvement automatique de plus de cinq secondes. Le format n'offre aucun contrôle natif, contrairement à `<video>`.

Le site en compte **32 animés** (34 GIF au total), répartis sur **30 pages**, pour **53 occurrences** dans le contenu. 14 d'entre eux dépassent 5 secondes sur une seule boucle — mais comme un GIF boucle sans fin, tous sont concernés.

## Ce que fait cette PR

Un processeur Stenope enveloppe chaque `<img>` en `.gif` du contenu dans un conteneur muni d'un bouton lecture / pause, en haut à gauche du visuel.

**Pourquoi au build et non en Twig** : ces images viennent du markdown des articles, elles n'ont pas de gabarit où insérer un bouton. Le processeur suit exactement le motif de `HtmlTablesProcessor`, arrivé avec #700.

**Comment la pause fonctionne** : le format n'expose aucune API de lecture, on ne peut ni l'arrêter ni lire sa position. La seule prise possible est de recopier l'image telle qu'elle est affichée sur un `<canvas>`, puis de masquer le GIF derrière. Visuellement plus rien ne bouge — ce que le critère demande.

*Conséquence assumée* : la reprise repart de la première image. Le GIF est retiré du rendu pendant la pause, le navigateur est donc libre de réinitialiser sa boucle. Pour un contenu illustratif, mieux vaut ça qu'un décodage qui continue en arrière-plan.

## Choix à connaître pour relire

**Le nom accessible du bouton change avec l'état** — « Mettre l'animation en pause » puis « Lancer l'animation » — plutôt qu'un libellé fixe doublé d'un `aria-pressed`. Les deux mécanismes ensemble se recouvrent et se lisent mal.

**Fond opaque `$color-dark` sous le pictogramme blanc**, et non un fond translucide : le contraste de la commande ne doit pas dépendre de l'image qui se trouve dessous. Blanc sur `$color-dark` donne 11,86:1, très au-delà des 3:1 exigés pour un élément non textuel.

**Le conteneur reprend le `margin: 35px auto` que `generic/_img.scss` posait sur l'image.** Laissée sur l'image, cette marge se retrouvait *à l'intérieur* du conteneur : le bouton flottait 35 px au-dessus du visuel et le centrage horizontal sautait. Le défaut est apparu au test, il est corrigé.

**Démarrage en pause sous `prefers-reduced-motion`** — au-delà de ce qui était demandé, mais une préférence système explicite vaut demande. La commande reste là pour lancer l'animation. Dites-le si vous préférez que l'animation démarre toujours.

**Seuls les GIF sont ciblés.** Les PNG et WebP animés existent, mais le dépôt n'en contient aucun et les détecter demanderait de lire l'en-tête de chaque fichier.

## Un retour voisin réglé au passage, sans code

La ligne 20 de la check-list — **« changements brusques de luminosité ou effet de flash »**, mesure PEAT — était restée sans verdict. J'ai analysé les 32 GIF animés selon les seuils de WCAG 2.3.1 : **aucun n'est à risque**. Maximum observé : 1 transition de luminance par seconde, contre 3 autorisées, sur des surfaces toutes supérieures au seuil de 21 824 px².

Réserve : l'analyse approxime PEAT — luminance moyenne par image plutôt que plus grande zone contiguë en scintillement, et pas de détection spécifique du rouge saturé. Avec une marge d'un facteur 3, la conclusion tient. **La ligne peut passer en conforme.**

## Tests

`npx eslint` OK · `make lint.twig` OK (53 fichiers) · `php-cs-fixer` 0 fichier à corriger · `lint:yaml` OK · `make test` OK, 609 pages.

**Vérifié sur le HTML généré** : 53 `<img *.gif>` dans le build, **53 enrobées, 0 orpheline**.

**Vérifié au navigateur** — pause : canvas créé à la taille naturelle (749×517), peint, image masquée, libellé basculé. Reprise : canvas retiré, image restaurée. Le conteneur épouse exactement l'image (749×517) et reste centré. Le bouton est bien sur le visuel, porte l'anneau de focus global et fait 36×36 px. Sous `prefers-reduced-motion` simulé, la page démarre en pause avec le canvas déjà peint.

**Reste à valider à la main** : le rendu sur quelques articles aux formats de GIF variés, et un passage VoiceOver pour juger l'annonce du changement de libellé.
