### PR TITLE
[CI] Déclenche le déploiement de prod à 8h30 Europe/Paris

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,8 @@ name: Deploy production
 on:
   workflow_dispatch: ~
   schedule:
-    - cron: '30 7 * * 1,2,3,4,5' # At 08:30 (UTC, => 08:30 / 09:30 in Europe/Paris depending on the DST), each day of the week.
+    - cron: '30 8 * * 1,2,3,4,5' # At 08:30 in Europe/Paris (DST handled by GitHub), monday to friday.
+      timezone: 'Europe/Paris'
   push:
     branches:
       - main


### PR DESCRIPTION
Le cron était en UTC, donc le déploiement partait à 8h30 l'hiver et 9h30 l'été. GitHub Actions supporte désormais un champ `timezone` à côté du `cron`, ce qui fixe l'heure toute l'année.

Source : https://github.blog/changelog/2026-03-19-github-actions-late-march-2026-updates/