### PR TITLE
[A11y] Déplace la commande des images animées côté client

### DIFF
--- a/assets/js/controllers/animated_image_controller.js
+++ b/assets/js/controllers/animated_image_controller.js
@@ -38,6 +38,10 @@ export default class extends Controller {
         this.frames = null;
         this.index = 0;
         this.timer = null;
+        this.playing = false;
+        // Marque la boucle de lecture courante : le décodage étant asynchrone, une
+        // boucle abandonnée peut reprendre après qu'une autre a été lancée.
+        this.generation = 0;
         this.canvas = null;
         this.decoder = null;
         this.toggleButton = null;
@@ -98,6 +102,9 @@ export default class extends Controller {
 
     pause() {
         this._stopTimer();
+        // Abandonne la boucle courante : sans quoi celle qui attend un décodage
+        // reprendrait la main après la pause.
+        ++this.generation;
         this._setState(false);
     }
 
@@ -107,7 +114,7 @@ export default class extends Controller {
         }
 
         this._setState(true);
-        this._advance();
+        this._advance(++this.generation);
     }
 
     // — Lecture pilotée ————————————————————————————————————————————————
@@ -146,10 +153,21 @@ export default class extends Controller {
 
             this.decoder = decoder;
             this.frames = track.frameCount;
-            this._mountCanvas();
+
+            // Le canvas est rendu hors document, puis substitué à l'image une fois la
+            // première image dessinée : posé avant, il resterait vide le temps du
+            // décodage, à la place d'une image déjà visible.
+            this._createCanvas();
 
             await this._render(0);
 
+            if (this.destroyed) {
+                this._abandonTakeOver();
+
+                return;
+            }
+
+            this._showCanvas();
             this._mountToggle();
 
             if (this.reduced) {
@@ -172,6 +190,13 @@ export default class extends Controller {
 
             this._mountToggle();
             this._setState(true);
+
+            // Le mode dégradé doit honorer `prefers-reduced-motion` comme le fait
+            // l'absence de décodeur : l'échec du décodage n'est pas une raison de
+            // laisser tourner l'animation.
+            if (this.reduced) {
+                this._whenLoaded(() => this._freeze());
+            }
         }
     }
 
@@ -184,12 +209,10 @@ export default class extends Controller {
         this.imageTarget.hidden = false;
     }
 
-    _mountCanvas() {
+    _createCanvas() {
         const image = this.imageTarget;
         const canvas = document.createElement('canvas');
 
-        canvas.width = image.naturalWidth;
-        canvas.height = image.naturalHeight;
         canvas.className = 'animated-image__frame';
 
         // Le canvas devient le rendu visible : il reprend l'alternative textuelle
@@ -204,13 +227,15 @@ export default class extends Controller {
             canvas.setAttribute('aria-hidden', 'true');
         }
 
-        image.after(canvas);
-        image.hidden = true;
-
         this.canvas = canvas;
         // Surtout pas `this.context` : Stimulus s'en sert pour son propre contexte,
         // et l'écraser casse `this.element` — donc tout le contrôleur, en silence.
         this.ctx = canvas.getContext('2d');
+    }
+
+    _showCanvas() {
+        this.imageTarget.after(this.canvas);
+        this.imageTarget.hidden = true;
     }
 
     async _render(index) {
@@ -218,16 +243,26 @@ export default class extends Controller {
             return 100;
         }
 
-        const { image } = await this.decoder.decode({ frameIndex: index });
+        // L'échec du décodage n'est pas rattrapé ici : `_takeOver` en a besoin pour
+        // rendre la main au `<img>`, et `_advance` pour arrêter la boucle.
+        const { image: frame } = await this.decoder.decode({ frameIndex: index });
+
+        // Les dimensions viennent de l'image décodée et non du `<img>` : celui-ci peut
+        // n'être pas encore chargé quand on prend la main, ses dimensions intrinsèques
+        // valent alors 0, et le canvas serait invisible.
+        if (this.canvas.width !== frame.displayWidth || this.canvas.height !== frame.displayHeight) {
+            this.canvas.width = frame.displayWidth;
+            this.canvas.height = frame.displayHeight;
+        }
 
         this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-        this.ctx.drawImage(image, 0, 0);
+        this.ctx.drawImage(frame, 0, 0);
 
         // `duration` est en microsecondes, et peut manquer. Les navigateurs
         // imposent un plancher de 20 ms aux GIF, on s'aligne dessus.
-        const duration = image.duration ? image.duration / 1000 : 100;
+        const duration = frame.duration ? frame.duration / 1000 : 100;
 
-        image.close();
+        frame.close();
 
         return Math.max(duration, 20);
     }
@@ -235,19 +270,36 @@ export default class extends Controller {
     /**
      * Rend l'image courante puis programme la suivante. Le décodage étant
      * asynchrone, on revérifie l'état de lecture après l'attente : une pause
-     * demandée entre-temps ne doit pas relancer la boucle.
+     * demandée entre-temps ne doit pas relancer la boucle. `generation` distingue
+     * les boucles entre elles — sans quoi une pause puis une reprise pendant un
+     * décodage en laisseraient deux tourner de front, avançant l'animation deux
+     * fois plus vite et n'en programmant plus qu'une seule à couper.
      */
-    async _advance() {
-        const delay = await this._render(this.index);
+    async _advance(generation) {
+        if (generation !== this.generation) {
+            return;
+        }
 
-        if (this.destroyed || !this.playing) {
+        let delay;
+
+        try {
+            delay = await this._render(this.index);
+        } catch {
+            // `close()` sur le décodeur — donc un démontage pendant l'attente — rejette
+            // le décodage en cours. Rien à signaler, il n'y a plus rien à rendre. Et si
+            // le décodage échoue pour une autre raison, la boucle s'arrête au lieu de
+            // relancer indéfiniment un décodage voué à échouer.
+            return;
+        }
+
+        if (this.destroyed || !this.playing || generation !== this.generation) {
             return;
         }
 
         this.timer = window.setTimeout(() => {
             this.timer = null;
             this.index = (this.index + 1) % this.frames;
-            this._advance();
+            this._advance(generation);
         }, delay);
     }
 
@@ -261,6 +313,13 @@ export default class extends Controller {
     // — Mode dégradé ———————————————————————————————————————————————————
 
     _freeze() {
+        // L'attente du chargement de l'image survit au démontage du contrôleur : une
+        // navigation Swup avant la fin du chargement ne doit pas geler une image qui
+        // n'est plus dans le document.
+        if (this.destroyed) {
+            return;
+        }
+
         const image = this.imageTarget;
 
         if (this.canvas || !image.naturalWidth) {

--- a/assets/js/controllers/animated_image_controller.js
+++ b/assets/js/controllers/animated_image_controller.js
@@ -19,14 +19,20 @@ const LABEL_STOP = 'Arrêter l’animation';
  * pause consiste alors simplement à ne pas programmer l'image suivante — ce qui
  * s'arrête est bien ce qui est affiché.
  *
- * `ImageDecoder` manque encore à certains navigateurs, Safari en tête. On y
- * conserve le `<img>` natif et la commande fige la première image : le mouvement
- * cesse, ce que le critère demande, mais sans reprise au point d'arrêt. Le nom du
- * bouton change en conséquence, pour ne pas promettre une pause qui n'en est pas
- * une.
+ * `ImageDecoder` manque encore à certains navigateurs, Safari en tête, et n'existe
+ * que dans un contexte sécurisé. On y conserve le `<img>` natif et la commande fige
+ * la première image : le mouvement cesse, ce que le critère demande, mais sans
+ * reprise au point d'arrêt. Le nom du bouton change en conséquence, pour ne pas
+ * promettre une pause qui n'en est pas une.
+ *
+ * Le bouton est construit ici et non par `HtmlAnimatedImagesProcessor`, parce que
+ * son existence même dépend du décodage : un GIF d'une seule image n'a rien à
+ * contrôler, et le libellé n'est connu qu'une fois su ce que le navigateur permet.
+ * Rendu au build, il aurait affirmé un contrôle avant de savoir s'il aura un
+ * effet — et serait resté visible mais inerte si le script échouait à se charger.
  */
 export default class extends Controller {
-    static targets = ['image', 'label'];
+    static targets = ['image'];
 
     connect() {
         this.frames = null;
@@ -34,12 +40,17 @@ export default class extends Controller {
         this.timer = null;
         this.canvas = null;
         this.decoder = null;
+        this.toggleButton = null;
+        this.label = null;
         this.destroyed = false;
         this.reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
         this.supported = typeof window.ImageDecoder !== 'undefined';
 
         if (!this.supported) {
-            this._setLabel(LABEL_STOP);
+            // Ici la capacité est connue d'emblée : la commande peut être posée tout
+            // de suite, dans le seul état qu'elle pourra tenir.
+            this._mountToggle();
+            this._setState(true);
 
             if (this.reduced) {
                 this._whenLoaded(() => this._freeze());
@@ -69,6 +80,9 @@ export default class extends Controller {
         this.decoder = null;
         this.canvas?.remove();
         this.canvas = null;
+        this.toggleButton?.remove();
+        this.toggleButton = null;
+        this.label = null;
     }
 
     toggle() {
@@ -116,11 +130,10 @@ export default class extends Controller {
 
             const track = decoder.tracks.selectedTrack;
 
-            // Un GIF d'une seule image n'a rien à contrôler : on retire la commande
-            // plutôt que d'afficher un bouton sans effet.
+            // Un GIF d'une seule image n'a rien à contrôler : on repart sans poser
+            // de commande, plutôt que d'en afficher une sans effet.
             if (!track || track.frameCount < 2) {
                 decoder.close();
-                this.element.classList.add('animated-image--static');
 
                 return;
             }
@@ -137,16 +150,38 @@ export default class extends Controller {
 
             await this._render(0);
 
+            this._mountToggle();
+
             if (this.reduced) {
                 this._setState(false);
             } else {
                 this.play();
             }
         } catch {
-            // Décodage impossible (réseau, format inattendu) : le `<img>` continue de
-            // jouer et la commande retombe sur le gel première image.
-            this._setLabel(LABEL_STOP);
+            // Une navigation Swup pendant le `fetch` fait rejeter la requête : rien à
+            // remonter, le contrôleur est déjà démonté.
+            if (this.destroyed) {
+                return;
+            }
+
+            // Décodage impossible (réseau, format inattendu) : on défait ce qui a pu
+            // être posé avant l'échec — sans quoi le bouton promettrait une pause
+            // dont on n'est plus capable, par-dessus un canvas resté vide — puis le
+            // `<img>` reprend la main et la commande retombe sur le gel.
+            this._abandonTakeOver();
+
+            this._mountToggle();
+            this._setState(true);
         }
+    }
+
+    _abandonTakeOver() {
+        this.decoder?.close();
+        this.decoder = null;
+        this.frames = null;
+        this.canvas?.remove();
+        this.canvas = null;
+        this.imageTarget.hidden = false;
     }
 
     _mountCanvas() {
@@ -256,6 +291,39 @@ export default class extends Controller {
 
     // — Commun ——————————————————————————————————————————————————————————
 
+    /**
+     * Le nom accessible change avec l'état plutôt que d'être fixe et doublé d'un
+     * `aria-pressed` : les deux mécanismes ensemble se recouvrent, et « Lancer
+     * l'animation » dit à lui seul ce que fera l'activation.
+     *
+     * Les deux pictogrammes sont posés ensemble et permutés par la feuille de style
+     * selon la classe d'état, pour que l'état visuel ne soit décrit qu'à un endroit.
+     */
+    _mountToggle() {
+        if (this.toggleButton) {
+            return;
+        }
+
+        const button = document.createElement('button');
+
+        button.type = 'button';
+        button.className = 'animated-image__toggle';
+        button.innerHTML = `
+            <span class="animated-image__icons" aria-hidden="true">
+                <svg class="animated-image__icon animated-image__icon--pause" viewBox="0 0 24 24" width="18" height="18" focusable="false" aria-hidden="true"><path fill="currentColor" d="M8 5h3v14H8zm5 0h3v14h-3z"/></svg>
+                <svg class="animated-image__icon animated-image__icon--play" viewBox="0 0 24 24" width="18" height="18" focusable="false" aria-hidden="true"><path fill="currentColor" d="M8 5l11 7-11 7z"/></svg>
+            </span>
+            <span class="screen-reader"></span>
+        `;
+
+        button.addEventListener('click', () => this.toggle());
+
+        this.element.appendChild(button);
+
+        this.toggleButton = button;
+        this.label = button.querySelector('.screen-reader');
+    }
+
     _setState(playing) {
         this.playing = playing;
         this.element.classList.toggle('animated-image--paused', !playing);
@@ -263,8 +331,8 @@ export default class extends Controller {
     }
 
     _setLabel(text) {
-        if (this.hasLabelTarget) {
-            this.labelTarget.textContent = text;
+        if (this.label) {
+            this.label.textContent = text;
         }
     }
 

--- a/assets/scss/components/_animated-image.scss
+++ b/assets/scss/components/_animated-image.scss
@@ -65,13 +65,9 @@
   display: block;
 }
 
-// La permutation est portée par la classe d'état plutôt que par le JS, pour que
-// le rendu reste cohérent si le script n'a pas encore pris la main.
+// La permutation est portée par la classe d'état plutôt que par le JS : l'état
+// visuel du bouton n'est ainsi décrit qu'à un seul endroit.
 .animated-image__icon--play { display: none; }
-
-// Une image d'une seule vue n'a rien à contrôler : le décodeur retire la commande
-// plutôt que d'afficher un bouton sans effet.
-.animated-image--static .animated-image__toggle { display: none; }
 
 .animated-image--paused {
   .animated-image__icon--pause { display: none; }

--- a/src/Stenope/Processor/HtmlAnimatedImagesProcessor.php
+++ b/src/Stenope/Processor/HtmlAnimatedImagesProcessor.php
@@ -30,9 +30,9 @@ use Stenope\Bundle\Content;
  * affirmé avant qu'on sache s'il aura un effet, et inerte si le script échoue à se
  * charger.
  *
- * Seuls les GIF sont concernés. Les PNG et WebP animés existent mais le dépôt
- * n'en contient aucun, et les détecter demanderait de lire l'en-tête de chaque
- * fichier — on s'en tiendra à l'extension tant que ce n'est pas nécessaire.
+ * Seuls les GIF sont concernés, elaomojis exclus. Les PNG et WebP animés existent
+ * mais le dépôt n'en contient aucun, et les détecter demanderait de lire l'en-tête
+ * de chaque fichier — on s'en tiendra à l'extension tant que ce n'est pas nécessaire.
  */
 class HtmlAnimatedImagesProcessor implements ProcessorInterface
 {
@@ -55,7 +55,13 @@ class HtmlAnimatedImagesProcessor implements ProcessorInterface
             return;
         }
 
-        $images = $crawler->filter('img');
+        // Les elaomojis sont des GIF, mais des GIF de la taille d'un caractère, posés
+        // au fil du texte par `ElaomojisProcessor` (`.emoji` vaut `height: 1em` et
+        // `display: inline-block`). Les enrober les arracherait de leur phrase — le
+        // conteneur est un bloc centré avec ses propres marges — et la commande y
+        // serait plus grande que l'image qu'elle contrôle. Le critère vise le
+        // mouvement qui s'impose à la lecture, pas un emoji de 25 px au fil d'un texte.
+        $images = $crawler->filter('img:not(.emoji)');
 
         if (0 === $images->count()) {
             return;

--- a/src/Stenope/Processor/HtmlAnimatedImagesProcessor.php
+++ b/src/Stenope/Processor/HtmlAnimatedImagesProcessor.php
@@ -9,25 +9,30 @@ use Stenope\Bundle\Behaviour\ProcessorInterface;
 use Stenope\Bundle\Content;
 
 /**
- * Enveloppe les images animées du contenu dans un conteneur muni d'une commande
- * de lecture / pause.
+ * Enveloppe les images animées du contenu dans un conteneur confié à
+ * `animated_image_controller`, qui y pose une commande de lecture / pause.
  *
  * Un GIF animé démarre seul et boucle indéfiniment : il entre donc dans le champ
  * de WCAG 2.2.2 (RGAA 13.8), qui exige un moyen de mettre en pause, arrêter ou
  * masquer tout mouvement automatique de plus de cinq secondes. Le format n'offre
- * aucun contrôle natif, contrairement à `<video>` — d'où cette commande ajoutée
- * au build.
+ * aucun contrôle natif, contrairement à `<video>` — d'où cette commande.
  *
  * Le conteneur est produit ici plutôt qu'en Twig parce que ces images viennent du
- * markdown des articles : elles n'ont pas de gabarit où insérer un bouton.
+ * markdown des articles : elles n'ont pas de gabarit où l'insérer. Et il est
+ * produit au build plutôt que côté client parce qu'il porte la mise en page :
+ * `.animated-image` reprend la marge que `generic/_img.scss` posait sur l'image,
+ * l'ajouter après coup décalerait le contenu.
+ *
+ * La commande, elle, est posée par le contrôleur. Son existence et son libellé
+ * dépendent de ce que le navigateur sait faire : un GIF d'une seule image n'a rien
+ * à contrôler, et sans `ImageDecoder` la commande arrête l'animation au lieu de la
+ * suspendre. Rien de tout cela n'est connu au build — un bouton rendu ici serait
+ * affirmé avant qu'on sache s'il aura un effet, et inerte si le script échoue à se
+ * charger.
  *
  * Seuls les GIF sont concernés. Les PNG et WebP animés existent mais le dépôt
  * n'en contient aucun, et les détecter demanderait de lire l'en-tête de chaque
  * fichier — on s'en tiendra à l'extension tant que ce n'est pas nécessaire.
- *
- * La mise en pause elle-même est faite côté client (`animated_image_controller`) :
- * elle consiste à figer l'image courante sur un canvas. Rien ne peut la produire
- * au build, puisqu'il s'agit de l'état de l'animation au moment du clic.
  */
 class HtmlAnimatedImagesProcessor implements ProcessorInterface
 {
@@ -113,59 +118,5 @@ class HtmlAnimatedImagesProcessor implements ProcessorInterface
         $wrapper->appendChild($image);
 
         $image->setAttribute('data-animated-image-target', 'image');
-
-        $wrapper->appendChild($this->createToggle($document));
-    }
-
-    /**
-     * Le nom accessible du bouton change avec l'état plutôt que d'être fixe et
-     * doublé d'un `aria-pressed` : les deux mécanismes ensemble se recouvrent, et
-     * « Lancer l'animation » dit à lui seul ce que fera l'activation.
-     *
-     * Les deux pictogrammes sont posés ici et permutés par la feuille de style
-     * selon l'état : le bouton reste utilisable si le JS échoue à se charger —
-     * il ne fera rien, mais il n'affichera pas non plus un état mensonger.
-     */
-    private function createToggle(\DOMDocument $document): \DOMElement
-    {
-        $button = $document->createElement('button');
-        $button->setAttribute('type', 'button');
-        $button->setAttribute('class', 'animated-image__toggle');
-        $button->setAttribute('data-animated-image-target', 'toggle');
-        $button->setAttribute('data-action', 'animated-image#toggle');
-
-        $icons = $document->createElement('span');
-        $icons->setAttribute('class', 'animated-image__icons');
-        $icons->setAttribute('aria-hidden', 'true');
-        $icons->appendChild($this->createIcon($document, 'pause'));
-        $icons->appendChild($this->createIcon($document, 'play'));
-        $button->appendChild($icons);
-
-        $label = $document->createElement('span', 'Mettre l’animation en pause');
-        $label->setAttribute('class', 'screen-reader');
-        $label->setAttribute('data-animated-image-target', 'label');
-        $button->appendChild($label);
-
-        return $button;
-    }
-
-    private function createIcon(\DOMDocument $document, string $name): \DOMElement
-    {
-        $svg = $document->createElement('svg');
-        $svg->setAttribute('class', "animated-image__icon animated-image__icon--$name");
-        $svg->setAttribute('viewBox', '0 0 24 24');
-        $svg->setAttribute('width', '18');
-        $svg->setAttribute('height', '18');
-        $svg->setAttribute('focusable', 'false');
-        $svg->setAttribute('aria-hidden', 'true');
-
-        $path = $document->createElement('path');
-        $path->setAttribute('fill', 'currentColor');
-        $path->setAttribute('d', 'pause' === $name
-            ? 'M8 5h3v14H8zm5 0h3v14h-3z'
-            : 'M8 5l11 7-11 7z');
-        $svg->appendChild($path);
-
-        return $svg;
     }
 }

--- a/src/Stenope/Processor/HtmlAnimatedImagesProcessor.php
+++ b/src/Stenope/Processor/HtmlAnimatedImagesProcessor.php
@@ -104,9 +104,21 @@ class HtmlAnimatedImagesProcessor implements ProcessorInterface
     private function wrap(\DOMElement $image): void
     {
         $document = $image->ownerDocument;
-        $parent = $image->parentNode;
 
-        if (null === $document || null === $parent) {
+        if (null === $document) {
+            return;
+        }
+
+        // Quand l'image est le seul contenu de son paragraphe — ce que produit le
+        // markdown `![…](…)` —, le conteneur prend la place du paragraphe au lieu de
+        // s'y nicher : un `<div>` dans un `<p>` est invalide, et l'analyseur du
+        // navigateur le remonte hors du paragraphe en synthétisant des paragraphes
+        // vides. L'arbre rendu ne correspondrait alors plus à celui pour lequel la
+        // feuille de style est écrite.
+        $target = $this->soleParagraphOf($image) ?? $image;
+        $parent = $target->parentNode;
+
+        if (null === $parent) {
             return;
         }
 
@@ -114,9 +126,37 @@ class HtmlAnimatedImagesProcessor implements ProcessorInterface
         $wrapper->setAttribute('class', 'animated-image');
         $wrapper->setAttribute('data-controller', 'animated-image');
 
-        $parent->replaceChild($wrapper, $image);
+        $parent->replaceChild($wrapper, $target);
         $wrapper->appendChild($image);
 
         $image->setAttribute('data-animated-image-target', 'image');
+    }
+
+    /**
+     * Le paragraphe dont l'image est le seul contenu, s'il y en a un.
+     */
+    private function soleParagraphOf(\DOMElement $image): ?\DOMElement
+    {
+        $parent = $image->parentNode;
+
+        if (!$parent instanceof \DOMElement || 'p' !== $parent->nodeName) {
+            return null;
+        }
+
+        foreach ($parent->childNodes as $node) {
+            if ($node === $image) {
+                continue;
+            }
+
+            // Le markdown laisse des retours à la ligne autour de l'image : seul un
+            // contenu visible interdit de remplacer le paragraphe.
+            if ($node instanceof \DOMText && '' === trim($node->wholeText)) {
+                continue;
+            }
+
+            return null;
+        }
+
+        return $parent;
     }
 }


### PR DESCRIPTION
Suggestion posée par-dessus #701 plutôt que dedans

Preview :
- article d'exemple avec le gif banana dance : https://elao.github.io/elao_/pr/704/blog/styleguide/example 
- article avec des elaomojis : https://elao.github.io/elao_/pr/704/blog/elao/amelie-integratrice-depuis-5-ans/

## 1. La commande de lecture passe côté client

Répond au fil https://github.com/Elao/elao_/pull/701#discussion_r3819542378.

Le processeur rendait le bouton au build, mais le contrôleur Stimulus le corrigeait aussitôt : il le masque sur un GIF d'une seule image, change son libellé quand `ImageDecoder` manque (Safari), et démarre en pause sous `prefers-reduced-motion`. Le markup serveur n'était donc jamais celui qui fait foi.

Le processeur ne rend plus que le conteneur ; le contrôleur Stimulus pose le bouton quand il sait ce qu'il peut promettre :

- GIF d'une seule image → aucun bouton
- pas d'`ImageDecoder` → « Arrêter l'animation »
- sinon → « Mettre l'animation en pause »

Au passage : plus de bouton visible mais inerte quand le JS ne se charge pas. Le conteneur, lui, reste produit au build ; c'est lui qui porte la mise en page de l'image.

## 2. Correctifs de robustesse

- le canvas prenait ses dimensions sur l'image HTML : 0×0, donc image invisible, si elle n'était pas encore chargée
- une navigation pendant la lecture provoquait une erreur JS non capturée
- pause puis reprise rapide lançait deux boucles de lecture, l'animation partait deux fois plus vite
- le conteneur était inséré *dans* le paragraphe de l'image : un `<div>` dans un `<p>`, HTML invalide
- `prefers-reduced-motion` n'était pas respecté quand le décodage échouait
- ménage : la classe `--static` et un attribut de cible inutilisé, tous deux devenus sans objet

## 3. Les elaomojis sortent du cadre

Le filtre portait sur l'extension `.gif`, et les elaomojis en sont. **16 des 53 images concernées étaient des emojis inline** : chacun se retrouvait arraché de sa phrase, seul sur une ligne centrée, avec un bouton plus grand que lui.

Ils sont désormais exclus du traitement — il reste 37 images enrobées.

| Avant (#701) | Après (cette PR) |
|---|---|
| <img width="2560" height="1440" alt="elaomoji-avant" src="https://github.com/user-attachments/assets/73a3b887-55f7-4271-914d-b21689f5d010" /> | <img width="2560" height="1440" alt="elaomoji-apres" src="https://github.com/user-attachments/assets/b889f1f1-9e79-4f85-aad7-10c22e648ea9" /> |
| [voir la page](https://elao.github.io/elao_/pr/701/blog/elao/amelie-integratrice-depuis-5-ans/) | [voir la page](https://elao.github.io/elao_/pr/704/blog/elao/amelie-integratrice-depuis-5-ans/) |

À noter, parce que c'est trompeur : la page `/elaomojis/` ne montre rien du problème. C'est une galerie, ce n'est pas du contenu d'article — seuls les articles passent par le processeur.

## Limite connue

Sans `ImageDecoder`, on ne peut pas savoir combien d'images compte un GIF. Sur Safari, les 2 GIF fixes du dépôt gardent donc un bouton sans effet. C'était déjà le cas avant cette PR.
